### PR TITLE
array constructor lambda reference support for Stream:collect method

### DIFF
--- a/src/main/java/com/annimon/stream/function/IntFunction.java
+++ b/src/main/java/com/annimon/stream/function/IntFunction.java
@@ -1,0 +1,25 @@
+package com.annimon.stream.function;
+
+/**
+ * Represents a function that accepts an int-valued argument and produces a
+ * result.  This is the {@code int}-consuming primitive specialization for
+ * {@link Function}.
+ *
+ * <p>This is a <a href="package-summary.html">functional interface</a>
+ * whose functional method is {@link #apply(int)}.
+ *
+ * @param <R> the type of the result of the function
+ *
+ * @see Function
+ */
+@FunctionalInterface
+public interface IntFunction<R> {
+
+    /**
+     * Applies this function to the given argument.
+     *
+     * @param value the function argument
+     * @return the function result
+     */
+    R apply(int value);
+}

--- a/src/test/java/com/annimon/stream/Functions.java
+++ b/src/test/java/com/annimon/stream/Functions.java
@@ -3,8 +3,11 @@ package com.annimon.stream;
 import com.annimon.stream.function.BiConsumer;
 import com.annimon.stream.function.BiFunction;
 import com.annimon.stream.function.Function;
+import com.annimon.stream.function.IntFunction;
 import com.annimon.stream.function.Predicate;
 import com.annimon.stream.function.Supplier;
+import java.lang.reflect.Array;
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.Map;
@@ -13,6 +16,17 @@ import java.util.Map;
  * Functions that used in tests.
  */
 public final class Functions {
+
+    public static <T> IntFunction<T[]> arrayGenerator(final Class<T[]> clazz) {
+        return new IntFunction<T[]>() {
+
+            @Override
+            @SuppressWarnings("unchecked")
+            public T[] apply(int value) {
+                return (T[]) Array.newInstance(clazz.getComponentType(), value);
+            }
+        };
+    }
     
     public static <T> Function<T, String> convertToString() {
         return new Function<T, String>() {

--- a/src/test/java/com/annimon/stream/StreamTest.java
+++ b/src/test/java/com/annimon/stream/StreamTest.java
@@ -738,6 +738,16 @@ public class StreamTest {
         assertNotNull(result.get());
         assertEquals(6, (int) result.get());
     }
+
+    @Test
+    public void testCollectToArrayTerminationOperation() {
+        Integer[] numbers = Stream.ofRange(1, 1000)
+               .filter(Functions.remainder(2))
+               .collect(Functions.arrayGenerator(Integer[].class));
+
+        assertTrue(numbers.length > 0);
+        assertNotNull(numbers[100]);
+    }
     
     @Test
     public void testCustomIntermediateOperator_Reverse() {


### PR DESCRIPTION
added new collect method that supports receiving array constructor reference;
added corresponding test case and back-port function;

this will look like:
int[] numbers = Stream.ofRange(1, 1000).filter(i % 5).collect(int[]::new);