### PR TITLE
Fix missing generic type specifier and unchecked casts

### DIFF
--- a/src/main/java/com/annimon/stream/Exceptional.java
+++ b/src/main/java/com/annimon/stream/Exceptional.java
@@ -151,7 +151,8 @@ public class Exceptional<T> {
      * @param consumer  a consumer function
      * @return an {@code Exceptional}
      */
-    public <E extends Throwable> Exceptional<T> ifExceptionIs(Class<E> throwableClass, Consumer<E> consumer) {
+    @SuppressWarnings("unchecked")
+    public <E extends Throwable> Exceptional<T> ifExceptionIs(Class<E> throwableClass, Consumer<? super E> consumer) {
         if ( (throwable != null) &&
                 (throwableClass.isAssignableFrom(throwable.getClass())) ) {
             consumer.accept((E) throwable);

--- a/src/main/java/com/annimon/stream/Optional.java
+++ b/src/main/java/com/annimon/stream/Optional.java
@@ -37,7 +37,7 @@ public class Optional<T> {
      * @see #of(java.lang.Object) 
      */
     public static <T> Optional<T> ofNullable(T value) {
-        return value == null ? (Optional<T>) EMPTY : of(value);
+        return value == null ? Optional.<T>empty() : of(value);
     }
     
     /**
@@ -46,6 +46,7 @@ public class Optional<T> {
      * @param <T> the type of value
      * @return an {@code Optional}
      */
+    @SuppressWarnings("unchecked")
     public static <T> Optional<T> empty() {
         return (Optional<T>) EMPTY;
     }
@@ -100,7 +101,7 @@ public class Optional<T> {
      */
     public Optional<T> filter(Predicate<? super T> predicate) {
         if (!isPresent()) return this;
-        return predicate.test(value) ? this : (Optional<T>) EMPTY;
+        return predicate.test(value) ? this : Optional.<T>empty();
     }
     
     /**

--- a/src/main/java/com/annimon/stream/Stream.java
+++ b/src/main/java/com/annimon/stream/Stream.java
@@ -663,7 +663,7 @@ public class Stream<T> {
      * @param f  the transformation function
      * @return the new stream
      */
-    public <R extends Comparable> Stream<T> sortBy(final Function<? super T, ? extends R> f) {
+    public <R extends Comparable<? super R>> Stream<T> sortBy(final Function<? super T, ? extends R> f) {
         return sorted(new Comparator<T>() {
             @Override
             public int compare(T o1, T o2) {
@@ -820,7 +820,7 @@ public class Stream<T> {
                 result = accumulator.apply(result, value);
             }
         }
-        return foundAny ? Optional.of(result) : (Optional<T>) Optional.empty();
+        return foundAny ? Optional.of(result) : Optional.<T>empty();
     }
 
     /**
@@ -904,7 +904,7 @@ public class Stream<T> {
         }
         if (collector.finisher() != null)
             return collector.finisher().apply(container);
-        return (R) container;
+        return Collectors.<A, R>castIdentity().apply(container);
     }
 
     /**

--- a/src/main/java/com/annimon/stream/function/Predicate.java
+++ b/src/main/java/com/annimon/stream/function/Predicate.java
@@ -82,7 +82,7 @@ public interface Predicate<T> {
          * @return a composed {@code Predicate}
          * @throws NullPointerException if {@code p1} is null
          */
-        public static <T> Predicate<? super T> negate(final Predicate<? super T> p1) {
+        public static <T> Predicate<T> negate(final Predicate<? super T> p1) {
             return new Predicate<T>() {
                 @Override
                 public boolean test(T value) {

--- a/src/test/java/com/annimon/stream/ExceptionalTest.java
+++ b/src/test/java/com/annimon/stream/ExceptionalTest.java
@@ -152,13 +152,13 @@ public class ExceptionalTest {
                         data[EXCEPTION] = true;
                     }
                 })
-                .ifExceptionIs(FileNotFoundException.class, new Consumer<FileNotFoundException>() {
+                .ifExceptionIs(FileNotFoundException.class, new Consumer<Throwable>() {
                     @Override
-                    public void accept(FileNotFoundException value) {
+                    public void accept(Throwable value) {
                         data[FILE_NOT_FOUND] = true;
                     }
                 });
-        
+
         assertTrue(data[INTERRUPTED]);
         assertTrue(data[EXCEPTION]);
         assertFalse(data[FILE_NOT_FOUND]);

--- a/src/test/java/com/annimon/stream/function/PredicateTest.java
+++ b/src/test/java/com/annimon/stream/function/PredicateTest.java
@@ -66,13 +66,13 @@ public class PredicateTest {
         TestUtils.testPrivateConstructor(Predicate.Util.class);
     }
     
-    private static final Predicate lessThan100 = new Predicate<Integer>() {
+    private static final Predicate<Integer> lessThan100 = new Predicate<Integer>() {
         @Override
         public boolean test(Integer value) {
             return value < 100;
         }
     };
     
-    private static final Predicate isEven = Functions.remainder(2);
+    private static final Predicate<Integer> isEven = Functions.remainder(2);
     
 }


### PR DESCRIPTION
No new feature, contains code and interface improvements only.

- Fixes unchecked casts
- Fixes missing sortBy() type parameter: from `<R extends Comparable>` to `<R extends Comparable<? super R>>`.
  - **This is incompatible change with misused Comparable type.** But it should not work even without this change if misused.
- Fixes Predicate.Util.negate() return type from `Predicate<? super T>` to `Predicate<T>`.
  - It wasn't able to assign to `Predicate<? super T>` variable, now it can assign to `Predicate<T>`.
- ifExceptionIs() now accepts Consumer with super Exception types.

Thanks!