### PR TITLE
chunkBy

### DIFF
--- a/src/main/java/com/annimon/stream/Stream.java
+++ b/src/main/java/com/annimon/stream/Stream.java
@@ -657,7 +657,7 @@ public class Stream<T> {
         return Stream.of( collect(Collectors.groupingBy(classifier)) );
     }
 	
-	/**
+    /**
      * Partitions {@code Stream} into {@code List}s according to the given classifier function. In contrast
      * to {@link #groupBy(Function)}, this method assumes that the elements of the stream are sorted.
      * Because of this assumption, it does not need to first collect all elements and then partition them.

--- a/src/test/java/com/annimon/stream/StreamTest.java
+++ b/src/test/java/com/annimon/stream/StreamTest.java
@@ -438,7 +438,7 @@ public class StreamTest {
         assertEquals("[2, 3, 2, 3, 2, 3]", pc2.toString());
     }
     
-	@Test
+    @Test
     public void testChunkBy() {
         final PrintConsumer<String> printConsumer = new PrintConsumer<String>();
 

--- a/src/test/java/com/annimon/stream/StreamTest.java
+++ b/src/test/java/com/annimon/stream/StreamTest.java
@@ -438,6 +438,35 @@ public class StreamTest {
         assertEquals("[2, 3, 2, 3, 2, 3]", pc2.toString());
     }
     
+	@Test
+    public void testChunkBy() {
+        final PrintConsumer<String> printConsumer = new PrintConsumer<String>();
+
+        Stream.of(1, 1, 2, 2, 2, 3, 1).chunkBy(new Function<Integer, Integer>() {
+            @Override
+            public Integer apply(Integer value) {
+                return value;
+            }
+        }).map(new Function<List<Integer>, String>() {
+            @Override
+            public String apply(List<Integer> list) {
+                StringBuilder sb = new StringBuilder();
+                sb.append("[");
+                for (Integer i : list) {
+                    sb.append(i);
+                    sb.append(", ");
+                }
+                sb.deleteCharAt(sb.length() - 2); // remove trailing comma
+                sb.deleteCharAt(sb.length() - 1); // remove trailing white space
+                sb.append("]");
+
+                return sb.toString();
+            }
+        }).forEach(printConsumer);
+
+        assertEquals("[1, 1][2, 2, 2][3][1]", printConsumer.toString());
+    }
+	
     @Test
     public void testPeek() {
         final PrintConsumer consumer = new PrintConsumer();

--- a/src/test/java/com/annimon/stream/StreamTest.java
+++ b/src/test/java/com/annimon/stream/StreamTest.java
@@ -491,31 +491,16 @@ public class StreamTest {
 
     @Test
     public void testChunkBy() {
-        final PrintConsumer<String> printConsumer = new PrintConsumer<String>();
+        final PrintConsumer<List<Integer>> consumer = new PrintConsumer<List<Integer>>();
 
         Stream.of(1, 1, 2, 2, 2, 3, 1).chunkBy(new Function<Integer, Integer>() {
             @Override
             public Integer apply(Integer value) {
                 return value;
             }
-        }).map(new Function<List<Integer>, String>() {
-            @Override
-            public String apply(List<Integer> list) {
-                StringBuilder sb = new StringBuilder();
-                sb.append("[");
-                for (Integer i : list) {
-                    sb.append(i);
-                    sb.append(", ");
-                }
-                sb.deleteCharAt(sb.length() - 2); // remove trailing comma
-                sb.deleteCharAt(sb.length() - 1); // remove trailing white space
-                sb.append("]");
+        }).forEach(consumer);
 
-                return sb.toString();
-            }
-        }).forEach(printConsumer);
-
-        assertEquals("[1, 1][2, 2, 2][3][1]", printConsumer.toString());
+        assertEquals("[1, 1][2, 2, 2][3][1]", consumer.toString());
     }
 	
     @Test


### PR DESCRIPTION
added `chunkBy()` method + test case

The `chunkBy()` method partitions the Stream into Lists according to the given classifier function. In contrast to `groupBy()`, this method assumes that the elements of the stream are sorted. Because of this assumption, it does not need to first collect all elements and then partition them. Instead, it can emit a List of elements when it reaches the first element that does not belong to the same chunk as the previous elements.

This is useful, for example, to process datasets from a database as they are usually sorted by time or some other criteria.