### PR TITLE
added slidingWindow() and sample()

### DIFF
--- a/src/main/java/com/annimon/stream/Stream.java
+++ b/src/main/java/com/annimon/stream/Stream.java
@@ -7,8 +7,10 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Queue;
 import java.util.Set;
 
 /**

--- a/src/main/java/com/annimon/stream/Stream.java
+++ b/src/main/java/com/annimon/stream/Stream.java
@@ -659,6 +659,102 @@ public class Stream<T> {
     public <K> Stream<Map.Entry<K, List<T>>> groupBy(final Function<? super T, ? extends K> classifier) {
         return Stream.of( collect(Collectors.groupingBy(classifier)) );
     }
+	
+    /**
+     * Samples the {@code Stream} by emitting every n-th element.
+     * <p>
+     * <p>This is an intermediate operation.
+     *
+     * @param stepWidth step width
+     * @return the new stream
+     */
+    public Stream<T> sample(final int stepWidth) {
+        return slidingWindow(1, stepWidth).map(new Function<List<T>, T>() {
+            @Override
+            public T apply(List<T> list) {
+                return list.get(0);
+            }
+        });
+    }
+
+    /**
+     * Partitions {@code Stream} into {@code List}s of fixed size by sliding over the elements of the stream.
+     * It starts with the first element and in each iteration moves by 1. This method yields the same results
+     * as calling {@link #slidingWindow(int, int)} with a {@code stepWidth} of 1. <p> <p>This is an
+     * intermediate operation.
+     *
+     * @param windowSize number of elements that will be emitted together in a list
+     * @return the new stream
+     * @see #slidingWindow(int, int)
+     */
+    public Stream<List<T>> slidingWindow(final int windowSize) {
+        return slidingWindow(windowSize, 1);
+    }
+
+    /**
+     * Partitions {@code Stream} into {@code List}s of fixed size by sliding over the elements of the stream.
+     * It starts with the first element and in each iteration moves by the given step width. This method
+     * allows, for example, to partition the elements into batches of {@code windowSize} elements (by using a
+     * step width equal to the specified window size) or to sample every n-th element (by using a window size
+     * of 1 and a step width of n).
+     * <p>
+     * <p>This is an intermediate operation.
+     * <p>
+     * <p>Examples: <pre>
+     * elements: [1, 1, 1, 2, 2, 2, 3, 3, 3]    windowSize: 3   stepWidth: 3
+     *
+     * =&gt; [1, 1, 1], [2, 2, 2] [3, 3, 3]
+     *
+     *
+     * elements: [1, 2, 3, 1, 2, 3, 1, 2, 3]    windowSize: 2   stepWidth: 3
+     *
+     * =&gt; [1, 2], [1, 2], [1, 2]
+     *
+     *
+     * elements: [1, 2, 3, 4, 5, 6]             windowSize: 3   stepWidth: 1
+     *
+     * =&gt; [1, 2, 3], [2, 3, 4], [3, 4, 5], [4, 5, 6]
+     * </pre>
+     *
+     * @param windowSize number of elements that will be emitted together in a list
+     * @param stepWidth  step width
+     * @return the new stream
+     */
+    public Stream<List<T>> slidingWindow(final int windowSize, final int stepWidth) {
+        return new Stream<List<T>>(new LsaIterator<List<T>>() {
+            private final Queue<T> queue = new LinkedList<T>();
+
+            @Override
+            public boolean hasNext() {
+                return iterator.hasNext();
+            }
+
+            @Override
+            public List<T> next() {
+                int i = queue.size();
+                while (iterator.hasNext() && i < windowSize) {
+                    queue.offer(iterator.next());
+                    i++;
+                }
+
+                // the elements that are currently in the queue are the elements of our current window
+                List<T> list = new ArrayList<T>(queue);
+
+                // remove stepWidth elements from the queue
+                int queueSize = queue.size();
+                for (int j = 0; j < stepWidth && j < queueSize; j++) {
+                    queue.poll();
+                }
+
+                // if the stepWidth is greater than the windowSize, skip (stepWidth - windowSize) elements
+                for (int j = windowSize; iterator.hasNext() && j < stepWidth; j++) {
+                    iterator.next();
+                }
+
+                return list;
+            }
+        });
+    }
 
     /**
      * Perform provided action to each elements.

--- a/src/test/java/com/annimon/stream/StreamTest.java
+++ b/src/test/java/com/annimon/stream/StreamTest.java
@@ -488,6 +488,39 @@ public class StreamTest {
         assertEquals("[1, 1, 1]", pc1.toString());
         assertEquals("[2, 3, 2, 3, 2, 3]", pc2.toString());
     }
+	
+    @Test
+    public void testSample() {
+        final PrintConsumer<Integer> pc1 = new PrintConsumer<Integer>();
+        Stream.of(1, 2, 3, 1, 2, 3, 1, 2, 3).sample(3).forEach(pc1);
+        assertEquals("111", pc1.toString());
+    }
+
+    @Test
+    public void testSlidingWindow() {
+        long count = Stream.of(new ArrayList<Integer>()).slidingWindow(5, 6).count();
+        assertEquals(0, count);
+
+        final PrintConsumer<List<Integer>> pc1 = new PrintConsumer<List<Integer>>();
+        Stream.of(1, 1, 1, 2, 2, 2, 3, 3, 3).slidingWindow(3, 3).forEach(pc1);
+        assertEquals("[1, 1, 1][2, 2, 2][3, 3, 3]", pc1.toString());
+
+        final PrintConsumer<List<Integer>> pc2 = new PrintConsumer<List<Integer>>();
+        Stream.of(1, 2, 3, 1, 2, 3, 1, 2, 3).slidingWindow(2, 3).forEach(pc2);
+        assertEquals("[1, 2][1, 2][1, 2]", pc2.toString());
+
+        final PrintConsumer<List<Integer>> pc3 = new PrintConsumer<List<Integer>>();
+        Stream.of(1, 2, 3, 4, 5, 6).slidingWindow(3, 1).forEach(pc3);
+        assertEquals("[1, 2, 3][2, 3, 4][3, 4, 5][4, 5, 6]", pc3.toString());
+
+        final PrintConsumer<List<Integer>> pc4 = new PrintConsumer<List<Integer>>();
+        Stream.of(1, 2, 3, 4, 5, 6).slidingWindow(3).forEach(pc4);
+        assertEquals("[1, 2, 3][2, 3, 4][3, 4, 5][4, 5, 6]", pc4.toString());
+
+        final PrintConsumer<List<Integer>> pc5 = new PrintConsumer<List<Integer>>();
+        Stream.of(1, 2).slidingWindow(3, 1).forEach(pc5);
+        assertEquals("[1, 2]", pc5.toString());
+    }
 
     @Test
     public void testPeek() {


### PR DESCRIPTION
- added `sample()` which emits every n-th element
- added `slidingWindow()`

`slidingWindow()` partitions the Stream into Lists of fixed size by sliding over the elements of the stream. It starts with the first element and in each iteration moves by the given step width. This method allows, for example, to partition the elements into batches of `windowSize` elements (by using a step width equal to the specified window size) or to sample every n-th element (by using a window size of 1 and a step width of n).

Examples:

elements: [1, 1, 1, 2, 2, 2, 3, 3, 3]
windowSize: 3
stepWidth: 3
=> [1, 1, 1], [2, 2, 2] [3, 3, 3]


elements: [1, 2, 3, 1, 2, 3, 1, 2, 3]
windowSize: 2
stepWidth: 3
=> [1, 2], [1, 2], [1, 2]


elements: [1, 2, 3, 4, 5, 6]
windowSize: 3
stepWidth: 1
=> [1, 2, 3], [2, 3, 4], [3, 4, 5], [4, 5, 6]

Signed-off-by: solderra <solderra@gmail.com>