### PR TITLE
Fix non-RandomAccess List accessed by index

### DIFF
--- a/stream/build.gradle
+++ b/stream/build.gradle
@@ -39,7 +39,7 @@ buildscript {
 
 cobertura {
     coverageFormats = ['html', 'xml']
-    coverageExcludes = ['.*com.annimon.stream.LsaIterator', '.*com.annimon.stream.LsaExtIterator']
+    coverageExcludes = ['.*com.annimon.stream.LsaIterator', '.*com.annimon.stream.LsaExtIterator', '.*com.annimon.stream.LazyIterator']
 }
 
 // maven signing

--- a/stream/src/main/java/com/annimon/stream/LazyIterator.java
+++ b/stream/src/main/java/com/annimon/stream/LazyIterator.java
@@ -1,0 +1,38 @@
+package com.annimon.stream;
+
+import java.util.Iterator;
+
+class LazyIterator<T> implements Iterator<T> {
+    private final Iterable<? extends T> iterable;
+    private Iterator<? extends T> iterator;
+
+    public LazyIterator(Iterable<? extends T> iterable) {
+        this.iterable = iterable;
+    }
+
+    private void ensureIterator() {
+        if (iterator != null) {
+            return;
+        }
+        // Lazily creates Iterator object.
+        iterator = iterable.iterator();
+    }
+
+    @Override
+    public boolean hasNext() {
+        ensureIterator();
+        return iterator.hasNext();
+    }
+
+    @Override
+    public T next() {
+        ensureIterator();
+        return iterator.next();
+    }
+
+    @Override
+    public void remove() {
+        ensureIterator();
+        iterator.remove();
+    }
+}

--- a/stream/src/main/java/com/annimon/stream/LsaExtIterator.java
+++ b/stream/src/main/java/com/annimon/stream/LsaExtIterator.java
@@ -1,6 +1,7 @@
 package com.annimon.stream;
 
 import java.util.Iterator;
+import java.util.NoSuchElementException;
 
 public abstract class LsaExtIterator<T> implements Iterator<T> {
 
@@ -18,6 +19,9 @@ public abstract class LsaExtIterator<T> implements Iterator<T> {
 
     @Override
     public T next() {
+        if (!hasNext) {
+            throw new NoSuchElementException();
+        }
         final T result = next;
         nextIteration();
         return result;

--- a/stream/src/main/java/com/annimon/stream/LsaIterator.java
+++ b/stream/src/main/java/com/annimon/stream/LsaIterator.java
@@ -1,6 +1,7 @@
 package com.annimon.stream;
 
 import java.util.Iterator;
+import java.util.NoSuchElementException;
 
 /**
  *
@@ -12,4 +13,14 @@ abstract class LsaIterator<T> implements Iterator<T> {
     public void remove() {
         throw new UnsupportedOperationException("remove not supported");
     }
+
+    @Override
+    public final T next() {
+        if (!hasNext()) {
+            throw new NoSuchElementException();
+        }
+        return nextIteration();
+    }
+
+    public abstract T nextIteration();
 }

--- a/stream/src/main/java/com/annimon/stream/Stream.java
+++ b/stream/src/main/java/com/annimon/stream/Stream.java
@@ -82,7 +82,7 @@ public class Stream<T> {
             }
 
             @Override
-            public T next() {
+            public T nextIteration() {
                 return elements[index++];
             }
         });
@@ -107,7 +107,7 @@ public class Stream<T> {
             }
 
             @Override
-            public Integer next() {
+            public Integer nextIteration() {
                 return index++;
             }
         });
@@ -146,7 +146,7 @@ public class Stream<T> {
             }
 
             @Override
-            public Long next() {
+            public Long nextIteration() {
                 return index++;
             }
         });
@@ -186,7 +186,7 @@ public class Stream<T> {
             }
 
             @Override
-            public Integer next() {
+            public Integer nextIteration() {
                 if (index >= to) {
                     hasNext = false;
                     return to;
@@ -230,7 +230,7 @@ public class Stream<T> {
             }
 
             @Override
-            public Long next() {
+            public Long nextIteration() {
                 if (index >= to) {
                     hasNext = false;
                     return to;
@@ -270,7 +270,7 @@ public class Stream<T> {
             }
 
             @Override
-            public T next() {
+            public T nextIteration() {
                 return supplier.get();
             }
         });
@@ -296,7 +296,7 @@ public class Stream<T> {
             }
 
             @Override
-            public T next() {
+            public T nextIteration() {
                 if (firstRun) {
                     firstRun = false;
                     t = seed;
@@ -359,7 +359,7 @@ public class Stream<T> {
             }
 
             @Override
-            public R next() {
+            public R nextIteration() {
                 return combiner.apply(it1.next(), it2.next());
             }
         });
@@ -491,7 +491,7 @@ public class Stream<T> {
             }
 
             @Override
-            public R next() {
+            public R nextIteration() {
                 return mapper.apply(iterator.next());
             }
         });
@@ -672,7 +672,7 @@ public class Stream<T> {
             }
 
             @Override
-            public List<T> next() {
+            public List<T> nextIteration() {
                 K key = classifier.apply(peek());
 
                 List<T> list = new ArrayList<T>();
@@ -771,7 +771,7 @@ public class Stream<T> {
             }
 
             @Override
-            public List<T> next() {
+            public List<T> nextIteration() {
                 int i = queue.size();
                 while (iterator.hasNext() && i < windowSize) {
                     queue.offer(iterator.next());
@@ -814,7 +814,7 @@ public class Stream<T> {
             }
 
             @Override
-            public T next() {
+            public T nextIteration() {
                 final T value = iterator.next();
                 action.accept(value);
                 return value;
@@ -890,7 +890,7 @@ public class Stream<T> {
             }
 
             @Override
-            public T next() {
+            public T nextIteration() {
                 index++;
                 return iterator.next();
             }
@@ -923,7 +923,7 @@ public class Stream<T> {
             }
 
             @Override
-            public T next() {
+            public T nextIteration() {
                 return iterator.next();
             }
         });

--- a/stream/src/main/java/com/annimon/stream/Stream.java
+++ b/stream/src/main/java/com/annimon/stream/Stream.java
@@ -31,30 +31,6 @@ public class Stream<T> {
     }
 
     /**
-     * Creates a {@code Stream} from {@code List}.
-     *
-     * @param <T> the type of the stream elements
-     * @param list  the list with elements to be passed to stream
-     * @return the new stream
-     */
-    public static <T> Stream<T> of(final List<? extends T> list) {
-        return new Stream<T>(new LsaIterator<T>() {
-
-            private int index = 0;
-
-            @Override
-            public boolean hasNext() {
-                return index < list.size();
-            }
-
-            @Override
-            public T next() {
-                return list.get(index++);
-            }
-        });
-    }
-
-    /**
      * Creates a {@code Stream} from {@code Map} entries.
      *
      * @param <K> the type of map keys

--- a/stream/src/main/java/com/annimon/stream/Stream.java
+++ b/stream/src/main/java/com/annimon/stream/Stream.java
@@ -377,7 +377,7 @@ public class Stream<T> {
     }
 
     private Stream(Iterable<? extends T> iterable) {
-        this(iterable.iterator());
+        this(new LazyIterator<T>(iterable));
     }
 
     /**

--- a/stream/src/test/java/com/annimon/stream/IteratorIssueTest.java
+++ b/stream/src/test/java/com/annimon/stream/IteratorIssueTest.java
@@ -45,7 +45,7 @@ public class IteratorIssueTest {
         assertEquals(count, stream.count());
     }
     
-    @Test(expected = ConcurrentModificationException.class)
+    @Test
     public void testHashSetIterator() {
         final int count = 5;
         final Set<Integer> data = new HashSet<Integer>();


### PR DESCRIPTION
`of(final List<? extends T> list)` can receive LinkedList, which does not implement `RandomAccess` and does not offer fast random access using indexes.

List is just Iterable, so simply removing it solves the issue :)