### PR TITLE
Added select(Class) method to filter stream by type.

### DIFF
--- a/stream/src/main/java/com/annimon/stream/Stream.java
+++ b/stream/src/main/java/com/annimon/stream/Stream.java
@@ -486,6 +486,26 @@ public class Stream<T> {
     }
 
     /**
+     * Returns a stream consisting of the elements of this stream which are
+     * instances of given class.
+     *
+     * <p>This is an intermediate operation.
+     *
+     * @param <TT> a type of instances to select.
+     * @param clazz a class which instances should be selected
+     * @return the new stream of type passed as param
+     */
+    @SuppressWarnings("unchecked")
+    public <TT> Stream<TT> select(final Class<TT> clazz) {
+        return (Stream<TT>) filter(new Predicate<T>() {
+            @Override
+            public boolean test(T value) {
+                return clazz.isInstance(value);
+            }
+        });
+    }
+
+    /**
      * Returns {@code Stream} with elements that obtained by applying the given function.
      *
      * <p>This is an intermediate operation.

--- a/stream/src/test/java/com/annimon/stream/StreamTest.java
+++ b/stream/src/test/java/com/annimon/stream/StreamTest.java
@@ -9,9 +9,9 @@ import com.annimon.stream.function.Predicate;
 import com.annimon.stream.function.Supplier;
 import com.annimon.stream.function.UnaryOperator;
 import com.annimon.stream.test.OptionalMatcher;
-import static com.annimon.stream.test.OptionalMatcher.isPresent;
-import static com.annimon.stream.test.StreamMatcher.elements;
-import static com.annimon.stream.test.StreamMatcher.isEmpty;
+
+import org.junit.Test;
+
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -19,9 +19,17 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
-import org.junit.Test;
+
+import static com.annimon.stream.test.OptionalMatcher.isPresent;
+import static com.annimon.stream.test.StreamMatcher.elements;
+import static com.annimon.stream.test.StreamMatcher.isEmpty;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests {@code Stream}.
@@ -245,6 +253,22 @@ public class StreamTest {
                 .filter(Functions.remainder(2))
                 .forEach(consumer);
         assertEquals("02468", consumer.toString());
+    }
+
+    @Test
+    public void testSelect() {
+
+        final PrintConsumer<String> consumer = new PrintConsumer<String>();
+
+        Stream.of(1, "a", 2, "b", 3, "cc").select(String.class)
+                .filter(new Predicate<String>() {
+                    @Override
+                    public boolean test(String value) {
+                        return value.length() == 1;
+                    }
+                }).forEach(consumer);
+
+        assertEquals("ab", consumer.toString());
     }
 
     @Test


### PR DESCRIPTION
From time to time I have to filter collection of objects by type and this looks very monstrous, for example:
`Stream.of(shapes).filter(s -> s instanceof ShapeDrawable).forEach(s->((ShapeDrawable)s).hide());`

with method select this will transform into:
`Stream.of(shapes).select(ShapeDrawable.class).forEach(ShapeDrawable::hide);`

P.S.
feature ~~rip-off~~ inspired by https://github.com/amaembo/streamex