### PR TITLE
Android 2.1, 2.2 issue workaround

### DIFF
--- a/stream/src/main/java/com/annimon/stream/Stream.java
+++ b/stream/src/main/java/com/annimon/stream/Stream.java
@@ -1,6 +1,8 @@
 package com.annimon.stream;
 
 import com.annimon.stream.function.*;
+
+import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -1241,7 +1243,22 @@ public class Stream<T> {
 
     @SafeVarargs
     static <E> E[] newArray(int length, E... array) {
-        return Arrays.copyOf(array, length);
+        try {
+            return Arrays.copyOf(array, length);
+        } catch (NoSuchMethodError nme) {
+            return newArrayCompat(length, array);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    static<E> E[] newArrayCompat(int length, E... array) {
+
+        final E[] res = (E[])Array.newInstance(array.getClass().getComponentType(), length);
+
+        for(int i = 0; i < res.length && i < array.length; i++)
+            res[i] = array[i];
+
+        return res;
     }
 
     private List<T> collectToList() {

--- a/stream/src/main/java/com/annimon/stream/Stream.java
+++ b/stream/src/main/java/com/annimon/stream/Stream.java
@@ -1255,8 +1255,7 @@ public class Stream<T> {
 
         final E[] res = (E[])Array.newInstance(array.getClass().getComponentType(), length);
 
-        for(int i = 0; i < res.length && i < array.length; i++)
-            res[i] = array[i];
+        System.arraycopy(array, 0, res, 0, Math.min(length, array.length));
 
         return res;
     }

--- a/stream/src/test/java/com/annimon/stream/StreamTest.java
+++ b/stream/src/test/java/com/annimon/stream/StreamTest.java
@@ -1018,6 +1018,28 @@ public class StreamTest {
     }
 
     @Test
+    public void testNewArrayCompat() {
+        String[] strings = new String[] {"abc", "def", "fff"};
+
+        String[] copy = Stream.newArrayCompat(5, strings);
+
+        assertEquals(5, copy.length);
+        assertEquals("abc", copy[0]);
+        assertEquals(null, copy[3]);
+
+        String[] empty = new String[0];
+
+        String[] emptyCopy = Stream.newArrayCompat(3, empty);
+
+        assertEquals(3, emptyCopy.length);
+
+        emptyCopy = Stream.newArrayCompat(0, empty);
+
+        assertEquals(0, emptyCopy.length);
+    }
+
+
+    @Test
     public void testCustomTerminalOperator_ForEach() {
         PrintConsumer<Integer> consumer = new PrintConsumer<Integer>();
         Stream.range(0, 10)


### PR DESCRIPTION
Because method Arrays.copyOf added in android 2.3 (https://developer.android.com/reference/java/util/Arrays.html#copyOf(T[], int))
 next code will fail:

``` Stream.of("ab","bc","ce").toArray(String[]::new); ```

with Exception: 

```java.lang.NoSuchMethodError: java.util.Arrays.copyOf 
      at com.annimon.stream.Stream.newArray(Stream.java:1244)``` 

This pull request contains workaround for this issue.