### PR TITLE
Fix OptionalMatchers and StreamMatchers on null values

### DIFF
--- a/streamTest/src/main/java/com/annimon/stream/test/OptionalMatcher.java
+++ b/streamTest/src/main/java/com/annimon/stream/test/OptionalMatcher.java
@@ -1,7 +1,7 @@
 package com.annimon.stream.test;
 
 import com.annimon.stream.Optional;
-import static org.hamcrest.CoreMatchers.not;
+
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeDiagnosingMatcher;
@@ -15,7 +15,7 @@ public class OptionalMatcher {
     }
 
     public static Matcher<Optional<?>> isEmpty() {
-        return not(isPresent());
+        return new IsEmptyMatcher();
     }
 
     public static class IsPresentMatcher extends TypeSafeDiagnosingMatcher<Optional<?>> {
@@ -29,6 +29,20 @@ public class OptionalMatcher {
         @Override
         public void describeTo(Description description) {
             description.appendText("Optional value should be present");
+        }
+    }
+
+    public static class IsEmptyMatcher extends TypeSafeDiagnosingMatcher<Optional<?>> {
+
+        @Override
+        protected boolean matchesSafely(Optional<?> optional, Description mismatchDescription) {
+            mismatchDescription.appendText("Optional was present");
+            return !optional.isPresent();
+        }
+
+        @Override
+        public void describeTo(Description description) {
+            description.appendText("Optional value should be empty");
         }
     }
 }

--- a/streamTest/src/main/java/com/annimon/stream/test/StreamMatcher.java
+++ b/streamTest/src/main/java/com/annimon/stream/test/StreamMatcher.java
@@ -2,11 +2,14 @@ package com.annimon.stream.test;
 
 import com.annimon.stream.Collectors;
 import com.annimon.stream.Stream;
-import java.util.List;
-import static org.hamcrest.CoreMatchers.not;
+
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.not;
 
 public class StreamMatcher {
 
@@ -16,8 +19,16 @@ public class StreamMatcher {
         return new IsEmptyMatcher();
     }
 
+    /**
+     * @deprecated Use not({@link StreamMatcher#isEmpty()}) or {@link StreamMatcher#hasElements()} instead
+     */
+    @Deprecated
     public static Matcher<Stream<?>> isNotEmpty() {
         return not(isEmpty());
+    }
+
+    public static Matcher<Stream<?>> hasElements() {
+        return new HasElementsMatcher();
     }
 
     public static <T> Matcher<Stream<T>> elements(Matcher<List<T>> matcher) {
@@ -35,6 +46,20 @@ public class StreamMatcher {
         @Override
         public void describeTo(Description description) {
             description.appendText("an empty stream");
+        }
+    }
+
+    public static class HasElementsMatcher extends TypeSafeDiagnosingMatcher<Stream<?>> {
+
+        @Override
+        protected boolean matchesSafely(Stream<?> stream, Description mismatchDescription) {
+            mismatchDescription.appendText("Stream was empty");
+            return stream.count() > 0;
+        }
+
+        @Override
+        public void describeTo(Description description) {
+            description.appendText("a non-empty stream");
         }
     }
 

--- a/streamTest/src/test/java/com/annimon/stream/test/OptionalMatcherTest.java
+++ b/streamTest/src/test/java/com/annimon/stream/test/OptionalMatcherTest.java
@@ -1,14 +1,16 @@
 package com.annimon.stream.test;
 
 import com.annimon.stream.Optional;
+
+import org.junit.Test;
+
 import static com.annimon.stream.test.CommonMatcher.description;
 import static com.annimon.stream.test.CommonMatcher.hasOnlyPrivateConstructors;
 import static com.annimon.stream.test.OptionalMatcher.isEmpty;
 import static com.annimon.stream.test.OptionalMatcher.isPresent;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
-import static org.junit.Assert.*;
-import org.junit.Test;
+import static org.junit.Assert.assertThat;
 
 public class OptionalMatcherTest {
 
@@ -31,5 +33,17 @@ public class OptionalMatcherTest {
         Optional<Integer> optional = Optional.empty();
         assertThat(optional, isEmpty());
         assertThat(optional, not(isPresent()));
+
+        assertThat(isEmpty(), description(is("Optional value should be empty")));
+    }
+
+    @Test(expected = AssertionError.class)
+    public void testIsEmptyOnNullValue() {
+        assertThat(null, isEmpty());
+    }
+
+    @Test(expected = AssertionError.class)
+    public void testIsPresentOnNullValue() {
+        assertThat(null, isPresent());
     }
 }

--- a/streamTest/src/test/java/com/annimon/stream/test/StreamMatcherTest.java
+++ b/streamTest/src/test/java/com/annimon/stream/test/StreamMatcherTest.java
@@ -1,20 +1,27 @@
 package com.annimon.stream.test;
 
 import com.annimon.stream.Stream;
+
+import org.hamcrest.Matcher;
+import org.hamcrest.StringDescription;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
 import static com.annimon.stream.test.CommonMatcher.description;
 import static com.annimon.stream.test.CommonMatcher.hasOnlyPrivateConstructors;
 import static com.annimon.stream.test.StreamMatcher.elements;
+import static com.annimon.stream.test.StreamMatcher.hasElements;
 import static com.annimon.stream.test.StreamMatcher.isEmpty;
 import static com.annimon.stream.test.StreamMatcher.isNotEmpty;
-import java.util.Arrays;
-import java.util.List;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
-import org.hamcrest.Matcher;
-import org.hamcrest.StringDescription;
-import static org.junit.Assert.*;
-import org.junit.Test;
+import static org.hamcrest.CoreMatchers.not;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 public class StreamMatcherTest {
 
@@ -31,6 +38,31 @@ public class StreamMatcherTest {
         StringDescription description = new StringDescription();
         isEmpty().describeTo(description);
         assertThat(description.toString(), is("an empty stream"));
+    }
+
+    @Test
+    public void testHasElements() {
+        assertThat(Stream.of(1, 2), hasElements());
+        assertThat(Stream.empty(), not(hasElements()));
+
+        StringDescription description = new StringDescription();
+        hasElements().describeTo(description);
+        assertThat(description.toString(), is("a non-empty stream"));
+    }
+
+    @Test(expected = AssertionError.class)
+    public void testIsEmptyOnNullValue() {
+        assertThat(null, isEmpty());
+    }
+
+    @Test
+    public void testIsNotEmptyOnNullValue() {
+        assertThat(null, isNotEmpty());
+    }
+
+    @Test(expected = AssertionError.class)
+    public void testHasElementsOnNullValue() {
+        assertThat(null, hasElements());
     }
 
     @Test


### PR DESCRIPTION
Both OptionalMatchers and StreamMatchers are insensitive to `null` values.
Example:
`assertThat(null, isEmpty())` should not match and throw an exception.

For the same reason it is not wise to implement opposite matcher (`isPresent()` is opposite to `isEmpty()`) using Hamcrest `not()` as the opposite matcher will then match against `null` way in the same way.
Therefore a `StreamMatcher.isNotEmpty()` is deprecated with regards to a new `StreamMatcher.hasElements()`.
