### PR TITLE
Mockito optional matchers

### DIFF
--- a/streamTest/build.gradle
+++ b/streamTest/build.gradle
@@ -20,6 +20,7 @@ repositories {
 dependencies {
     compile project(':stream')
     compile 'org.hamcrest:hamcrest-core:1.3'
+    compile 'org.mockito:mockito-core:2.0.71-beta'
     testCompile group: 'junit', name: 'junit', version: '4.12'
 }
 

--- a/streamTest/src/main/java/com/annimon/stream/test/mockito/OptionalMatcher.java
+++ b/streamTest/src/main/java/com/annimon/stream/test/mockito/OptionalMatcher.java
@@ -1,0 +1,52 @@
+package com.annimon.stream.test.mockito;
+
+import com.annimon.stream.Optional;
+
+import org.mockito.ArgumentMatcher;
+
+import static org.mockito.Matchers.argThat;
+
+public class OptionalMatcher {
+
+    public static <T> Optional<T> anyPresentOptional() {
+        return argThat(new PresentOptionalMatcher<T>());
+    }
+
+    public static <T> Optional<T> anyPresentOptional(@SuppressWarnings("UnusedParameters") Class<T> clazz) {
+        return argThat(new PresentOptionalMatcher<T>());
+    }
+
+    public static <T> Optional<T> anyEmptyOptional() {
+        return argThat(new EmptyOptionalMatcher<T>());
+    }
+
+    public static <T> Optional<T> anyEmptyOptional(@SuppressWarnings("UnusedParameters") Class<T> clazz) {
+        return argThat(new EmptyOptionalMatcher<T>());
+    }
+
+    public static class PresentOptionalMatcher<T> implements ArgumentMatcher<Optional<T>> {
+
+        @Override
+        public boolean matches(Optional<T> argument) {
+            return argument != null && argument.isPresent();
+        }
+
+        @Override
+        public String toString() {
+            return "anyPresentOptional()";
+        }
+    }
+
+    public static class EmptyOptionalMatcher<T> implements ArgumentMatcher<Optional<T>> {
+
+        @Override
+        public boolean matches(Optional<T> argument) {
+            return argument != null && !argument.isPresent();
+        }
+
+        @Override
+        public String toString() {
+            return "anyEmptyOptional()";
+        }
+    }
+}

--- a/streamTest/src/main/java/com/annimon/stream/test/mockito/OptionalMatcher.java
+++ b/streamTest/src/main/java/com/annimon/stream/test/mockito/OptionalMatcher.java
@@ -8,6 +8,8 @@ import static org.mockito.Matchers.argThat;
 
 public class OptionalMatcher {
 
+    private OptionalMatcher() { }
+
     public static <T> Optional<T> anyPresentOptional() {
         return argThat(new PresentOptionalMatcher<T>());
     }

--- a/streamTest/src/test/java/com/annimon/stream/test/mockito/OptionalMatcherTest.java
+++ b/streamTest/src/test/java/com/annimon/stream/test/mockito/OptionalMatcherTest.java
@@ -1,0 +1,125 @@
+package com.annimon.stream.test.mockito;
+
+import com.annimon.stream.Optional;
+import com.annimon.stream.test.mockito.OptionalMatcher.EmptyOptionalMatcher;
+import com.annimon.stream.test.mockito.OptionalMatcher.PresentOptionalMatcher;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static com.annimon.stream.test.mockito.OptionalMatcher.anyEmptyOptional;
+import static com.annimon.stream.test.mockito.OptionalMatcher.anyPresentOptional;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public final class OptionalMatcherTest {
+
+    private static final Optional<Object> PRESENT_OBJECT_OPTIONAL = Optional.of(new Object());
+    private static final Optional<Object> EMPTY_OBJECT_OPTIONAL = Optional.empty();
+    private static final Optional<String> PRESENT_STRING_OPTIONAL = Optional.of("ANY_STRING");
+    private static final Optional<String> EMPTY_STRING_OPTIONAL = Optional.empty();
+
+    @Test
+    public void testPresentOptionalMatcherMatching() {
+        PresentOptionalMatcher<Object> matcher = new PresentOptionalMatcher<Object>();
+
+        assertTrue(matcher.matches(PRESENT_OBJECT_OPTIONAL));
+        assertFalse(matcher.matches(EMPTY_OBJECT_OPTIONAL));
+        assertFalse(matcher.matches(null));
+    }
+
+    @Test
+    public void testAnyPresentObjectOptionalWhenStubbing() {
+        Foo foo = Mockito.mock(Foo.class);
+        when(foo.barObject(anyPresentOptional())).thenReturn(true);
+
+        assertFalse(foo.barObject(EMPTY_OBJECT_OPTIONAL));
+        assertTrue(foo.barObject(PRESENT_OBJECT_OPTIONAL));
+    }
+
+    @Test
+    public void testAnyPresentObjectOptionalWhenVerifying() {
+        Foo foo = Mockito.mock(Foo.class);
+
+        foo.barObject(PRESENT_OBJECT_OPTIONAL);
+
+        verify(foo, times(1)).barObject(anyPresentOptional());
+        verify(foo, never()).barObject(anyEmptyOptional());
+    }
+
+    @Test
+    public void testAnyPresentStringOptionalWhenStubbing() {
+        Foo foo = Mockito.mock(Foo.class);
+        when(foo.barString(anyPresentOptional(String.class))).thenReturn(true);
+
+        assertFalse(foo.barString(EMPTY_STRING_OPTIONAL));
+        assertTrue(foo.barString(PRESENT_STRING_OPTIONAL));
+    }
+
+    @Test
+    public void testAnyPresentStringOptionalWhenVerifying() {
+        Foo foo = Mockito.mock(Foo.class);
+
+        foo.barString(PRESENT_STRING_OPTIONAL);
+
+        verify(foo, times(1)).barString(anyPresentOptional(String.class));
+        verify(foo, never()).barString(anyEmptyOptional(String.class));
+    }
+
+    @Test
+    public void testEmptyOptionalMatcherMatching() {
+        EmptyOptionalMatcher<Object> matcher = new EmptyOptionalMatcher<Object>();
+
+        assertFalse(matcher.matches(PRESENT_OBJECT_OPTIONAL));
+        assertTrue(matcher.matches(EMPTY_OBJECT_OPTIONAL));
+        assertFalse(matcher.matches(null));
+    }
+
+    @Test
+    public void testAnyEmptyObjectOptionalWhenStubbing() {
+        Foo foo = Mockito.mock(Foo.class);
+        when(foo.barObject(anyEmptyOptional())).thenReturn(true);
+
+        assertTrue(foo.barObject(EMPTY_OBJECT_OPTIONAL));
+        assertFalse(foo.barObject(PRESENT_OBJECT_OPTIONAL));
+    }
+
+    @Test
+    public void testAnyEmptyObjectOptionalWhenVerifying() {
+        Foo foo = Mockito.mock(Foo.class);
+
+        foo.barObject(EMPTY_OBJECT_OPTIONAL);
+
+        verify(foo, never()).barObject(anyPresentOptional());
+        verify(foo, times(1)).barObject(anyEmptyOptional());
+    }
+
+    @Test
+    public void testAnyEmptyStringOptionalWhenStubbing() {
+        Foo foo = Mockito.mock(Foo.class);
+        when(foo.barString(anyEmptyOptional(String.class))).thenReturn(true);
+
+        assertTrue(foo.barString(EMPTY_STRING_OPTIONAL));
+        assertFalse(foo.barString(PRESENT_STRING_OPTIONAL));
+    }
+
+    @Test
+    public void testAnyEmptyStringOptionalWhenVerifying() {
+        Foo foo = Mockito.mock(Foo.class);
+
+        foo.barString(EMPTY_STRING_OPTIONAL);
+
+        verify(foo, never()).barString(anyPresentOptional(String.class));
+        verify(foo, times(1)).barString(anyEmptyOptional(String.class));
+    }
+
+    private interface Foo {
+        boolean barObject(Optional<Object> argument);
+
+        boolean barString(Optional<String> argument);
+    }
+}

--- a/streamTest/src/test/java/com/annimon/stream/test/mockito/OptionalMatcherTest.java
+++ b/streamTest/src/test/java/com/annimon/stream/test/mockito/OptionalMatcherTest.java
@@ -9,6 +9,7 @@ import org.mockito.Mockito;
 
 import static com.annimon.stream.test.mockito.OptionalMatcher.anyEmptyOptional;
 import static com.annimon.stream.test.mockito.OptionalMatcher.anyPresentOptional;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.never;
@@ -30,6 +31,13 @@ public final class OptionalMatcherTest {
         assertTrue(matcher.matches(PRESENT_OBJECT_OPTIONAL));
         assertFalse(matcher.matches(EMPTY_OBJECT_OPTIONAL));
         assertFalse(matcher.matches(null));
+    }
+
+    @Test
+    public void testPresentOptionalMatcherToString() {
+        PresentOptionalMatcher<Object> matcher = new PresentOptionalMatcher<Object>();
+
+        assertEquals(matcher.toString(), "anyPresentOptional()");
     }
 
     @Test
@@ -77,6 +85,13 @@ public final class OptionalMatcherTest {
         assertFalse(matcher.matches(PRESENT_OBJECT_OPTIONAL));
         assertTrue(matcher.matches(EMPTY_OBJECT_OPTIONAL));
         assertFalse(matcher.matches(null));
+    }
+
+    @Test
+    public void testEmptyOptionalMatcherToString() {
+        EmptyOptionalMatcher<Object> matcher = new EmptyOptionalMatcher<Object>();
+
+        assertEquals(matcher.toString(), "anyEmptyOptional()");
     }
 
     @Test

--- a/streamTest/src/test/java/com/annimon/stream/test/mockito/OptionalMatcherTest.java
+++ b/streamTest/src/test/java/com/annimon/stream/test/mockito/OptionalMatcherTest.java
@@ -7,10 +7,12 @@ import com.annimon.stream.test.mockito.OptionalMatcher.PresentOptionalMatcher;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import static com.annimon.stream.test.CommonMatcher.hasOnlyPrivateConstructors;
 import static com.annimon.stream.test.mockito.OptionalMatcher.anyEmptyOptional;
 import static com.annimon.stream.test.mockito.OptionalMatcher.anyPresentOptional;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -23,6 +25,11 @@ public final class OptionalMatcherTest {
     private static final Optional<Object> EMPTY_OBJECT_OPTIONAL = Optional.empty();
     private static final Optional<String> PRESENT_STRING_OPTIONAL = Optional.of("ANY_STRING");
     private static final Optional<String> EMPTY_STRING_OPTIONAL = Optional.empty();
+
+    @Test
+    public void testPrivateConstructor() throws Exception {
+        assertThat(OptionalMatcher.class, hasOnlyPrivateConstructors());
+    }
 
     @Test
     public void testPresentOptionalMatcherMatching() {


### PR DESCRIPTION
Custom Mockito `ArgumentMatcher` for `Optional` that can be used to for enhanced stubbing and verification.
Example:
```
        Foo foo = mock(Foo.class);
        when(foo.bar(anyPresentOptional())).thenReturn(true);
        when(foo.bar(anyEmptyOptional())).thenReturn(false);
```

New Mockito matchers are placed in `mockito` sub-package. It might make sense to move existing Hamcrest matchers to `hamcrest` sub-package (that would be an API breaking change) or make a standalone test modules: `streamTestHamcrest` and `streamTestMockito`. What do you think @aNNiMON ?