### PR TITLE
Change interfaces generic type param names to be better suggested when implemented

### DIFF
--- a/stream/src/main/java/com/annimon/stream/function/Consumer.java
+++ b/stream/src/main/java/com/annimon/stream/function/Consumer.java
@@ -14,9 +14,9 @@ public interface Consumer<T> {
     /**
      * Performs operation on argument.
      *
-     * @param value  the input argument
+     * @param t  the input argument
      */
-    void accept(T value);
+    void accept(T t);
 
     class Util {
 

--- a/stream/src/main/java/com/annimon/stream/function/Function.java
+++ b/stream/src/main/java/com/annimon/stream/function/Function.java
@@ -12,10 +12,10 @@ public interface Function<T, R> {
     /**
      * Applies this function to the given argument.
      *
-     * @param value  an argument
+     * @param t  an argument
      * @return the function result
      */
-    R apply(T value);
+    R apply(T t);
 
     class Util {
 

--- a/stream/src/main/java/com/annimon/stream/function/ThrowableFunction.java
+++ b/stream/src/main/java/com/annimon/stream/function/ThrowableFunction.java
@@ -13,9 +13,9 @@ public interface ThrowableFunction<I, R, E extends Throwable> {
     /**
      * Applies this function to the given argument.
      *
-     * @param value  an argument
+     * @param i  an argument
      * @return the function result
      * @throws E an exception
      */
-    R apply(I value) throws E;
+    R apply(I i) throws E;
 }


### PR DESCRIPTION
This changes the parameters names of generic types in the interfaces, so when implementing them using IntelliJ IDEA (or Android Studio), they are better suggested. For instance, if the concrete type is `Person` with this change it will suggest `person` as the param name instead of `value`. Java 8 Stream API and [RxJava interfaces](https://github.com/ReactiveX/RxJava/blob/1.x/src/main/java/rx/functions/Func1.java#L24) do the same.