### PR TITLE
Replace LinkedList with ArrayDeque

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,1 +1,58 @@
 apply plugin: 'base'
+
+// Plugins
+buildscript {
+  repositories {
+    mavenCentral()
+  }
+
+  dependencies {
+    classpath 'net.saliman:gradle-cobertura-plugin:2.3.2'
+    classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.6.3'
+  }
+}
+
+apply plugin: 'net.saliman.cobertura'
+apply plugin: 'com.github.kt3k.coveralls'
+
+
+// Repositories
+repositories {
+  mavenCentral()
+}
+
+subprojects {
+  repositories {
+    mavenCentral()
+  }
+  apply plugin: 'com.github.kt3k.coveralls'
+}
+
+
+// Coverage
+cobertura {
+  coverageFormats = ['html', 'xml']
+  coverageReportDatafile = file("build/cobertura/cobertura.ser")
+  coverageReportDir = file("build/reports/coverage")
+  coverageExcludes = ['.*com.annimon.stream.Compat.*', '.*com.annimon.stream.test.hamcrest.CommonMatcher.*']
+
+  coverageDirs = []
+  coverageSourceDirs = []
+  coverageMergeDatafiles = []
+
+  rootProject.subprojects.each {
+    println it.buildDir
+    coverageFormats = ['html', 'xml']
+    coverageDirs << file("${it.buildDir}/classes/main")
+    coverageSourceDirs << file("${it.projectDir}/src/main/java")
+    coverageMergeDatafiles << file("${it.buildDir}/cobertura/cobertura.ser")
+  }
+}
+
+coveralls {
+  coberturaReportPath = "${rootProject.buildDir}/reports/coverage/coverage.xml"
+}
+
+tasks.coveralls {
+  dependsOn cobertura
+}

--- a/build.gradle
+++ b/build.gradle
@@ -54,5 +54,5 @@ coveralls {
 }
 
 tasks.coveralls {
-  dependsOn cobertura
+  dependsOn coberturaReport
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,58 +1,46 @@
-apply plugin: 'base'
-
 // Plugins
 buildscript {
-  repositories {
-    mavenCentral()
-  }
+    repositories {
+        mavenCentral()
+    }
 
-  dependencies {
-    classpath 'net.saliman:gradle-cobertura-plugin:2.3.2'
-    classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.6.3'
-  }
+    dependencies {
+        classpath 'net.saliman:gradle-cobertura-plugin:2.2.6'
+        classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.6.3'
+    }
 }
 
-apply plugin: 'net.saliman.cobertura'
 apply plugin: 'com.github.kt3k.coveralls'
+apply plugin: 'net.saliman.cobertura'
 
-
-// Repositories
-repositories {
-  mavenCentral()
+allprojects {
+    repositories {
+        mavenCentral()
+    }
 }
 
 subprojects {
-  repositories {
-    mavenCentral()
-  }
-  apply plugin: 'com.github.kt3k.coveralls'
+    apply plugin: 'net.saliman.cobertura'
+    cobertura {
+        coverageFormats = ['html', 'xml']
+    }
 }
 
-
-// Coverage
 cobertura {
-  coverageFormats = ['html', 'xml']
-  coverageReportDatafile = file("build/cobertura/cobertura.ser")
-  coverageReportDir = file("build/reports/coverage")
-  coverageExcludes = ['.*com.annimon.stream.Compat.*', '.*com.annimon.stream.test.hamcrest.CommonMatcher.*']
-
-  coverageDirs = []
-  coverageSourceDirs = []
-  coverageMergeDatafiles = []
-
-  rootProject.subprojects.each {
-    println it.buildDir
     coverageFormats = ['html', 'xml']
-    coverageDirs << file("${it.buildDir}/classes/main")
-    coverageSourceDirs << file("${it.projectDir}/src/main/java")
-    coverageMergeDatafiles << file("${it.buildDir}/cobertura/cobertura.ser")
-  }
+    coverageReportDatafile = file("build/cobertura/cobertura.ser")
+    coverageReportDir = file("build/reports/coverage")
+    coverageSourceDirs = subprojects.sourceSets.main.allSource.srcDirs.flatten()
+    coverageMergeDatafiles = subprojects.collect { file("${it.buildDir}/cobertura/cobertura.ser") }
+    coverageDirs = subprojects.collect { file("${it.buildDir}/classes/main") }
 }
 
 coveralls {
-  coberturaReportPath = "${rootProject.buildDir}/reports/coverage/coverage.xml"
+    coberturaReportPath = "${rootProject.buildDir}/reports/coverage/coverage.xml"
 }
 
+test.dependsOn(rootProject.subprojects.collect { ":${it.name}:cobertura" })
+
 tasks.coveralls {
-  dependsOn coberturaReport
+    dependsOn coberturaReport
 }

--- a/stream/build.gradle
+++ b/stream/build.gradle
@@ -23,27 +23,6 @@ dependencies {
     testCompile project(':streamTest')
 }
 
-// coveralls
-
-apply plugin: 'cobertura'
-apply plugin: 'com.github.kt3k.coveralls'
-
-buildscript {
-    repositories {
-        mavenCentral()
-    }
-
-    dependencies {
-        classpath 'net.saliman:gradle-cobertura-plugin:2.0.0'
-        classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.6.3'
-    }
-}
-
-cobertura {
-    coverageFormats = ['html', 'xml']
-    coverageExcludes = ['.*com.annimon.stream.Compat']
-}
-
 // maven signing
 if (ext.isReleaseVersion) {
     apply from: 'signing.gradle'

--- a/stream/build.gradle
+++ b/stream/build.gradle
@@ -23,6 +23,10 @@ dependencies {
     testCompile project(':streamTest')
 }
 
+cobertura {
+    coverageExcludes = ['.*com.annimon.stream.Compat.*']
+}
+
 // maven signing
 if (ext.isReleaseVersion) {
     apply from: 'signing.gradle'

--- a/stream/build.gradle
+++ b/stream/build.gradle
@@ -41,6 +41,7 @@ buildscript {
 
 cobertura {
     coverageFormats = ['html', 'xml']
+    coverageExcludes = ['.*com.annimon.stream.Compat']
 }
 
 // maven signing

--- a/stream/src/main/java/com/annimon/stream/Compat.java
+++ b/stream/src/main/java/com/annimon/stream/Compat.java
@@ -1,0 +1,38 @@
+package com.annimon.stream;
+
+import java.lang.reflect.Array;
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.Queue;
+
+/**
+ * Compatibility methods for Android API &lt; 9.
+ */
+final class Compat {
+
+    static <T> Queue<T> queue() {
+        // ArrayDeque was introduced in Android 2.3
+        try {
+            return new ArrayDeque<T>();
+        } catch (NoClassDefFoundError nce) {
+            return new LinkedList<T>();
+        }
+    }
+
+    @SafeVarargs
+    static <E> E[] newArray(int length, E... array) {
+        try {
+            return Arrays.copyOf(array, length);
+        } catch (NoSuchMethodError nme) {
+            return newArrayCompat(array, length);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    static <E> E[] newArrayCompat(E[] array, int length) {
+        final E[] res = (E[]) Array.newInstance(array.getClass().getComponentType(), length);
+        System.arraycopy(array, 0, res, 0, Math.min(length, array.length));
+        return res;
+    }
+}

--- a/stream/src/main/java/com/annimon/stream/Stream.java
+++ b/stream/src/main/java/com/annimon/stream/Stream.java
@@ -3,6 +3,7 @@ package com.annimon.stream;
 import com.annimon.stream.function.*;
 
 import java.lang.reflect.Array;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -923,7 +924,7 @@ public class Stream<T> {
      */
     public Stream<List<T>> slidingWindow(final int windowSize, final int stepWidth) {
         return new Stream<List<T>>(new LsaIterator<List<T>>() {
-            private final Queue<T> queue = new LinkedList<T>();
+            private final Queue<T> queue = queueCompat();
 
             @Override
             public boolean hasNext() {
@@ -1393,6 +1394,15 @@ public class Stream<T> {
             container.add(iterator.next());
         }
         return container;
+    }
+
+    private Queue<T> queueCompat() {
+        // ArrayDeque was introduced in Android 2.3
+        try {
+            return new ArrayDeque<T>();
+        } catch (NoClassDefFoundError nce) {
+            return new LinkedList<T>();
+        }
     }
 
 //</editor-fold>

--- a/stream/src/main/java/com/annimon/stream/Stream.java
+++ b/stream/src/main/java/com/annimon/stream/Stream.java
@@ -2,15 +2,11 @@ package com.annimon.stream;
 
 import com.annimon.stream.function.*;
 
-import java.lang.reflect.Array;
-import java.util.ArrayDeque;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -924,7 +920,7 @@ public class Stream<T> {
      */
     public Stream<List<T>> slidingWindow(final int windowSize, final int stepWidth) {
         return new Stream<List<T>>(new LsaIterator<List<T>>() {
-            private final Queue<T> queue = queueCompat();
+            private final Queue<T> queue = Compat.queue();
 
             @Override
             public boolean hasNext() {
@@ -943,8 +939,8 @@ public class Stream<T> {
                 List<T> list = new ArrayList<T>(queue);
 
                 // remove stepWidth elements from the queue
-                int queueSize = queue.size();
-                for (int j = 0; j < stepWidth && j < queueSize; j++) {
+                final int pollCount = Math.min(queue.size(), stepWidth);
+                for (int j = 0; j < pollCount; j++) {
                     queue.poll();
                 }
 
@@ -1192,7 +1188,7 @@ public class Stream<T> {
         if (size >= MAX_ARRAY_SIZE) throw new IllegalArgumentException(BAD_SIZE);
 
         //noinspection unchecked
-        T[] source = container.toArray(Stream.<T>newArray(size));
+        T[] source = container.toArray(Compat.<T>newArray(size));
         R[] boxed = generator.apply(size);
 
         //noinspection SuspiciousSystemArraycopy
@@ -1369,40 +1365,12 @@ public class Stream<T> {
         return !kindAny;
     }
 
-    @SafeVarargs
-    static <E> E[] newArray(int length, E... array) {
-        try {
-            return Arrays.copyOf(array, length);
-        } catch (NoSuchMethodError nme) {
-            return newArrayCompat(length, array);
-        }
-    }
-
-    @SuppressWarnings("unchecked")
-    static<E> E[] newArrayCompat(int length, E... array) {
-
-        final E[] res = (E[])Array.newInstance(array.getClass().getComponentType(), length);
-
-        System.arraycopy(array, 0, res, 0, Math.min(length, array.length));
-
-        return res;
-    }
-
     private List<T> collectToList() {
         final List<T> container = new ArrayList<T>();
         while (iterator.hasNext()) {
             container.add(iterator.next());
         }
         return container;
-    }
-
-    private Queue<T> queueCompat() {
-        // ArrayDeque was introduced in Android 2.3
-        try {
-            return new ArrayDeque<T>();
-        } catch (NoClassDefFoundError nce) {
-            return new LinkedList<T>();
-        }
     }
 
 //</editor-fold>

--- a/stream/src/test/java/com/annimon/stream/StreamTest.java
+++ b/stream/src/test/java/com/annimon/stream/StreamTest.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import static com.annimon.stream.test.hamcrest.OptionalMatcher.isPresent;
 import static com.annimon.stream.test.hamcrest.StreamMatcher.elements;
 import static com.annimon.stream.test.hamcrest.StreamMatcher.isEmpty;
+import java.util.NoSuchElementException;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.Matchers.instanceOf;
@@ -341,6 +342,22 @@ public class StreamTest {
                 .filterNot(Functions.remainder(2))
                 .forEach(consumer);
         assertEquals("13579", consumer.toString());
+    }
+
+    @Test(expected = NoSuchElementException.class)
+    public void testFilterIteratorNextOnEmpty() {
+        Stream.<Integer>empty()
+                .filter(Functions.remainder(2))
+                .iterator()
+                .next();
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testFilterIteratorRemove() {
+        Stream.range(0, 10)
+                .filter(Functions.remainder(2))
+                .iterator()
+                .remove();
     }
 
     @Test

--- a/stream/src/test/java/com/annimon/stream/StreamTest.java
+++ b/stream/src/test/java/com/annimon/stream/StreamTest.java
@@ -1168,7 +1168,7 @@ public class StreamTest {
     public void testNewArrayCompat() {
         String[] strings = new String[] {"abc", "def", "fff"};
 
-        String[] copy = Stream.newArrayCompat(5, strings);
+        String[] copy = Compat.newArrayCompat(strings, 5);
 
         assertEquals(5, copy.length);
         assertEquals("abc", copy[0]);
@@ -1176,11 +1176,11 @@ public class StreamTest {
 
         String[] empty = new String[0];
 
-        String[] emptyCopy = Stream.newArrayCompat(3, empty);
+        String[] emptyCopy = Compat.newArrayCompat(empty, 3);
 
         assertEquals(3, emptyCopy.length);
 
-        emptyCopy = Stream.newArrayCompat(0, empty);
+        emptyCopy = Compat.newArrayCompat(empty, 0);
 
         assertEquals(0, emptyCopy.length);
     }

--- a/streamTest/build.gradle
+++ b/streamTest/build.gradle
@@ -24,6 +24,10 @@ dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.12'
 }
 
+cobertura {
+    coverageExcludes = ['.*com.annimon.stream.test.hamcrest.CommonMatcher.*']
+}
+
 // maven signing
 if (ext.isReleaseVersion) {
     apply from: 'signing.gradle'

--- a/streamTest/build.gradle
+++ b/streamTest/build.gradle
@@ -24,27 +24,6 @@ dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.12'
 }
 
-// coveralls
-
-apply plugin: 'cobertura'
-apply plugin: 'com.github.kt3k.coveralls'
-
-buildscript {
-    repositories {
-        mavenCentral()
-    }
-
-    dependencies {
-        classpath 'net.saliman:gradle-cobertura-plugin:2.0.0'
-        classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.4.0'
-    }
-}
-
-cobertura {
-    coverageFormats = ['html', 'xml']
-    coverageExcludes = ['.*com.annimon.stream.test.hamcrest.CommonMatcher.*']
-}
-
 // maven signing
 if (ext.isReleaseVersion) {
     apply from: 'signing.gradle'


### PR DESCRIPTION
According to `ArrayDeque` javadoc:

> This class is likely to be faster than Stack when used as a stack, and faster than LinkedList when used as a queue.

Since ArrayDeque was introduced in Android 2.3, LSA will use LinkedList in pre API 9.

TODO: check whether the code works in  Android 2.1/2.2.