### PR TITLE
Distinct preserves order

### DIFF
--- a/stream/src/main/java/com/annimon/stream/Stream.java
+++ b/stream/src/main/java/com/annimon/stream/Stream.java
@@ -2,7 +2,16 @@ package com.annimon.stream;
 
 import com.annimon.stream.function.*;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedHashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Queue;
+import java.util.Set;
 
 /**
  * A sequence of elements supporting aggregate operations.

--- a/stream/src/main/java/com/annimon/stream/Stream.java
+++ b/stream/src/main/java/com/annimon/stream/Stream.java
@@ -2,16 +2,7 @@ package com.annimon.stream;
 
 import com.annimon.stream.function.*;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.NoSuchElementException;
-import java.util.Queue;
-import java.util.Set;
+import java.util.*;
 
 /**
  * A sequence of elements supporting aggregate operations.
@@ -707,7 +698,7 @@ public class Stream<T> {
             @Override
             protected void nextIteration() {
                 if (!isInit) {
-                    final Set<T> set = new HashSet<T>();
+                    final Set<T> set = new LinkedHashSet<T>();
                     while (iterator.hasNext()) {
                         set.add(iterator.next());
                     }

--- a/stream/src/test/java/com/annimon/stream/IntStreamTest.java
+++ b/stream/src/test/java/com/annimon/stream/IntStreamTest.java
@@ -8,8 +8,11 @@ import java.util.Arrays;
 import java.util.List;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.closeTo;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.*;
+
+import org.hamcrest.Matchers;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -260,7 +263,7 @@ public class IntStreamTest {
 
     @Test
     public void testDistinctLazy() {
-        Integer[] expected = { -1, 1, 2, 3, 5 };
+        Integer[] expected = { 1, 2, 3, 5, -1 };
 
         List<Integer> input = new ArrayList<Integer>();
         input.addAll(Arrays.asList(1, 1, 2, 3, 5));
@@ -269,8 +272,9 @@ public class IntStreamTest {
                 .distinct();
         input.addAll(Arrays.asList(3, 2, 1, 1, -1));
 
+
         List<Integer> actual = stream.boxed().collect(Collectors.<Integer>toList());
-        assertThat(actual, containsInAnyOrder(expected));
+        assertThat(actual, Matchers.contains(expected));
     }
 
     @Test

--- a/stream/src/test/java/com/annimon/stream/StreamTest.java
+++ b/stream/src/test/java/com/annimon/stream/StreamTest.java
@@ -530,6 +530,14 @@ public class StreamTest {
     }
 
     @Test
+    public void testDistinctPreservesOrder() {
+        List<Integer> expected = Arrays.asList(1, 2, 3, 5, -1);
+        Stream<Integer> stream = Stream.of(1, 1, 2, 3, 5, 3, 2, 1, 1, -1)
+                .distinct();
+        assertThat(stream, elements(is(expected)));
+    }
+
+    @Test
     public void testDistinctLazy() {
         List<Integer> expected = Arrays.asList(-1, 1, 2, 3, 5);
 


### PR DESCRIPTION
https://docs.oracle.com/javase/8/docs/api/java/util/stream/Stream.html#distinct--

According to the documentation `distinct()` should preserve the order in ordered streams. 

Updated implementation and tests.