### PR TITLE
Collectors improvements

### DIFF
--- a/stream/src/main/java/com/annimon/stream/Collectors.java
+++ b/stream/src/main/java/com/annimon/stream/Collectors.java
@@ -277,6 +277,7 @@ public final class Collectors {
      * @param <T> the type of the input elements
      * @param mapper  the mapping function which extracts value from element to calculate result
      * @return a {@code Collector}
+     * @since 1.1.3
      */
     public static <T> Collector<T, ?, Double> averagingInt(final ToIntFunction<? super T> mapper) {
         return new CollectorsImpl<T, long[], Double>(
@@ -312,6 +313,7 @@ public final class Collectors {
      * @param <T> the type of the input elements
      * @param mapper  the mapping function which extracts value from element to calculate result
      * @return a {@code Collector}
+     * @since 1.1.3
      */
     public static <T> Collector<T, ?, Integer> summingInt(final ToIntFunction<? super T> mapper) {
         return new CollectorsImpl<T, int[], Integer>(
@@ -345,6 +347,7 @@ public final class Collectors {
      * @param <T> the type of the input elements
      * @param mapper  the mapping function which extracts value from element to calculate result
      * @return a {@code Collector}
+     * @since 1.1.3
      */
     public static <T> Collector<T, ?, Long> summingLong(final ToLongFunction<? super T> mapper) {
         return new CollectorsImpl<T, long[], Long>(

--- a/stream/src/main/java/com/annimon/stream/Collectors.java
+++ b/stream/src/main/java/com/annimon/stream/Collectors.java
@@ -264,6 +264,7 @@ public final class Collectors {
                 new Function<Double[], Double>() {
                     @Override
                     public Double apply(Double[] t) {
+                        if (t[0] == 0) return 0d;
                         return t[1] / t[0];
                     }
                 }

--- a/stream/src/main/java/com/annimon/stream/Collectors.java
+++ b/stream/src/main/java/com/annimon/stream/Collectors.java
@@ -280,6 +280,34 @@ public final class Collectors {
      * @since 1.1.3
      */
     public static <T> Collector<T, ?, Double> averagingInt(final ToIntFunction<? super T> mapper) {
+        return averagingHelper(new BiConsumer<long[], T>() {
+            @Override
+            public void accept(long[] t, T u) {
+                t[0]++; // count
+                t[1] += mapper.applyAsInt(u); // sum
+            }
+        });
+    }
+
+    /**
+     * Returns a {@code Collector} that calculates average of long-valued input elements.
+     *
+     * @param <T> the type of the input elements
+     * @param mapper  the mapping function which extracts value from element to calculate result
+     * @return a {@code Collector}
+     * @since 1.1.3
+     */
+    public static <T> Collector<T, ?, Double> averagingLong(final ToLongFunction<? super T> mapper) {
+        return averagingHelper(new BiConsumer<long[], T>() {
+            @Override
+            public void accept(long[] t, T u) {
+                t[0]++; // count
+                t[1] += mapper.applyAsLong(u); // sum
+            }
+        });
+    }
+
+    private static <T> Collector<T, ?, Double> averagingHelper(final BiConsumer<long[], T> accumulator) {
         return new CollectorsImpl<T, long[], Double>(
 
                 new Supplier<long[]>() {
@@ -289,13 +317,7 @@ public final class Collectors {
                     }
                 },
 
-                new BiConsumer<long[], T>() {
-                    @Override
-                    public void accept(long[] t, T u) {
-                        t[0]++; // count
-                        t[1] += mapper.applyAsInt(u); // sum
-                    }
-                },
+                accumulator,
 
                 new Function<long[], Double>() {
                     @Override

--- a/stream/src/main/java/com/annimon/stream/Collectors.java
+++ b/stream/src/main/java/com/annimon/stream/Collectors.java
@@ -244,7 +244,8 @@ public final class Collectors {
                         if (value.length() == 0) {
                             return emptyValue;
                         } else {
-                            return value.toString() + suffix;
+                            value.append(suffix);
+                            return value.toString();
                         }
                     }
                 }

--- a/stream/src/main/java/com/annimon/stream/Collectors.java
+++ b/stream/src/main/java/com/annimon/stream/Collectors.java
@@ -538,6 +538,37 @@ public final class Collectors {
                 }
         );
     }
+
+    /**
+     * Returns a {@code Collector} that filters input elements.
+     *
+     * @param <T> the type of the input elements
+     * @param <A> the accumulation type
+     * @param <R> the type of the output elements
+     * @param predicate  a predicate used to filter elements
+     * @param downstream  the collector of filtered elements
+     * @return a {@code Collector}
+     * @since 1.1.3
+     */
+    public static <T, A, R> Collector<T, ?, R> filtering(
+            final Predicate<? super T> predicate,
+            final Collector<? super T, A, R> downstream) {
+        final BiConsumer<A, ? super T> accumulator = downstream.accumulator();
+        return new CollectorsImpl<T, A, R>(
+
+                downstream.supplier(),
+
+                new BiConsumer<A, T>() {
+                    @Override
+                    public void accept(A a, T t) {
+                        if (predicate.test(t))
+                            accumulator.accept(a, t);
+                    }
+                },
+
+                downstream.finisher()
+        );
+    }
     
     /**
      * Returns a {@code Collector} that performs mapping function before accumulation.

--- a/stream/src/main/java/com/annimon/stream/Collectors.java
+++ b/stream/src/main/java/com/annimon/stream/Collectors.java
@@ -98,6 +98,7 @@ public final class Collectors {
      * @param <K> the result type of key mapping function
      * @param keyMapper  a mapping function to produce keys
      * @return a {@code Collector}
+     * @since 1.1.3
      */
     public static <T, K> Collector<T, ?, Map<K, T>> toMap(
             final Function<? super T, ? extends K> keyMapper) {

--- a/stream/src/main/java/com/annimon/stream/Collectors.java
+++ b/stream/src/main/java/com/annimon/stream/Collectors.java
@@ -269,6 +269,41 @@ public final class Collectors {
                 }
         );
     }
+
+    /**
+     * Returns a {@code Collector} that calculates average of integer-valued input elements.
+     *
+     * @param <T> the type of the input elements
+     * @param mapper  the mapping function which extracts value from element to calculate result
+     * @return a {@code Collector}
+     */
+    public static <T> Collector<T, ?, Double> averagingInt(final ToIntFunction<? super T> mapper) {
+        return new CollectorsImpl<T, long[], Double>(
+
+                new Supplier<long[]>() {
+                    @Override
+                    public long[] get() {
+                        return new long[] { 0, 0 };
+                    }
+                },
+
+                new BiConsumer<long[], T>() {
+                    @Override
+                    public void accept(long[] t, T u) {
+                        t[0]++; // count
+                        t[1] += mapper.applyAsInt(u); // sum
+                    }
+                },
+
+                new Function<long[], Double>() {
+                    @Override
+                    public Double apply(long[] t) {
+                        if (t[0] == 0) return 0d;
+                        return t[1] / (double) t[0];
+                    }
+                }
+        );
+    }
     
     /**
      * Returns a {@code Collector} that counts the number of input elements.

--- a/stream/src/main/java/com/annimon/stream/Collectors.java
+++ b/stream/src/main/java/com/annimon/stream/Collectors.java
@@ -330,6 +330,42 @@ public final class Collectors {
     }
 
     /**
+     * Returns a {@code Collector} that calculates average of double-valued input elements.
+     *
+     * @param <T> the type of the input elements
+     * @param mapper  the mapping function which extracts value from element to calculate result
+     * @return a {@code Collector}
+     * @since 1.1.3
+     */
+    public static <T> Collector<T, ?, Double> averagingDouble(final ToDoubleFunction<? super T> mapper) {
+        return new CollectorsImpl<T, double[], Double>(
+
+                new Supplier<double[]>() {
+                    @Override
+                    public double[] get() {
+                        return new double[] { 0d, 0d };
+                    }
+                },
+
+                new BiConsumer<double[], T>() {
+                    @Override
+                    public void accept(double[] t, T u) {
+                        t[0]++; // count
+                        t[1] += mapper.applyAsDouble(u); // sum
+                    }
+                },
+
+                new Function<double[], Double>() {
+                    @Override
+                    public Double apply(double[] t) {
+                        if (t[0] == 0) return 0d;
+                        return t[1] / t[0];
+                    }
+                }
+        );
+    }
+
+    /**
      * Returns a {@code Collector} that summing integer-valued input elements.
      *
      * @param <T> the type of the input elements

--- a/stream/src/main/java/com/annimon/stream/Collectors.java
+++ b/stream/src/main/java/com/annimon/stream/Collectors.java
@@ -17,6 +17,20 @@ import java.util.Set;
  */
 public final class Collectors {
 
+    private static final Supplier<long[]> LONG_2ELEMENTS_ARRAY_SUPPLIER = new Supplier<long[]>() {
+        @Override
+        public long[] get() {
+            return new long[] { 0L, 0L };
+        }
+    };
+
+    private static final Supplier<double[]> DOUBLE_2ELEMENTS_ARRAY_SUPPLIER = new Supplier<double[]>() {
+        @Override
+        public double[] get() {
+            return new double[] { 0d, 0d };
+        }
+    };
+
     private Collectors() { }
     
     /**
@@ -296,12 +310,7 @@ public final class Collectors {
     private static <T> Collector<T, ?, Double> averagingHelper(final BiConsumer<long[], T> accumulator) {
         return new CollectorsImpl<T, long[], Double>(
 
-                new Supplier<long[]>() {
-                    @Override
-                    public long[] get() {
-                        return new long[] { 0, 0 };
-                    }
-                },
+                LONG_2ELEMENTS_ARRAY_SUPPLIER,
 
                 accumulator,
 
@@ -326,12 +335,7 @@ public final class Collectors {
     public static <T> Collector<T, ?, Double> averagingDouble(final ToDoubleFunction<? super T> mapper) {
         return new CollectorsImpl<T, double[], Double>(
 
-                new Supplier<double[]>() {
-                    @Override
-                    public double[] get() {
-                        return new double[] { 0d, 0d };
-                    }
-                },
+                DOUBLE_2ELEMENTS_ARRAY_SUPPLIER,
 
                 new BiConsumer<double[], T>() {
                     @Override
@@ -396,12 +400,7 @@ public final class Collectors {
     public static <T> Collector<T, ?, Long> summingLong(final ToLongFunction<? super T> mapper) {
         return new CollectorsImpl<T, long[], Long>(
 
-                new Supplier<long[]>() {
-                    @Override
-                    public long[] get() {
-                        return new long[] { 0L };
-                    }
-                },
+                LONG_2ELEMENTS_ARRAY_SUPPLIER,
 
                 new BiConsumer<long[], T>() {
                     @Override
@@ -430,12 +429,7 @@ public final class Collectors {
     public static <T> Collector<T, ?, Double> summingDouble(final ToDoubleFunction<? super T> mapper) {
         return new CollectorsImpl<T, double[], Double>(
 
-                new Supplier<double[]>() {
-                    @Override
-                    public double[] get() {
-                        return new double[] { 0d };
-                    }
-                },
+                DOUBLE_2ELEMENTS_ARRAY_SUPPLIER,
 
                 new BiConsumer<double[], T>() {
                     @Override

--- a/stream/src/main/java/com/annimon/stream/Collectors.java
+++ b/stream/src/main/java/com/annimon/stream/Collectors.java
@@ -418,6 +418,40 @@ public final class Collectors {
                 }
         );
     }
+
+    /**
+     * Returns a {@code Collector} that summing double-valued input elements.
+     *
+     * @param <T> the type of the input elements
+     * @param mapper  the mapping function which extracts value from element to calculate result
+     * @return a {@code Collector}
+     * @since 1.1.3
+     */
+    public static <T> Collector<T, ?, Double> summingDouble(final ToDoubleFunction<? super T> mapper) {
+        return new CollectorsImpl<T, double[], Double>(
+
+                new Supplier<double[]>() {
+                    @Override
+                    public double[] get() {
+                        return new double[] { 0d };
+                    }
+                },
+
+                new BiConsumer<double[], T>() {
+                    @Override
+                    public void accept(double[] t, T u) {
+                        t[0] += mapper.applyAsDouble(u);
+                    }
+                },
+
+                new Function<double[], Double>() {
+                    @Override
+                    public Double apply(double[] value) {
+                        return value[0];
+                    }
+                }
+        );
+    }
     
     /**
      * Returns a {@code Collector} that counts the number of input elements.

--- a/stream/src/main/java/com/annimon/stream/Collectors.java
+++ b/stream/src/main/java/com/annimon/stream/Collectors.java
@@ -305,6 +305,39 @@ public final class Collectors {
                 }
         );
     }
+
+    /**
+     * Returns a {@code Collector} that summing integer-valued input elements.
+     *
+     * @param <T> the type of the input elements
+     * @param mapper  the mapping function which extracts value from element to calculate result
+     * @return a {@code Collector}
+     */
+    public static <T> Collector<T, ?, Integer> summingInt(final ToIntFunction<? super T> mapper) {
+        return new CollectorsImpl<T, int[], Integer>(
+
+                new Supplier<int[]>() {
+                    @Override
+                    public int[] get() {
+                        return new int[] { 0 };
+                    }
+                },
+
+                new BiConsumer<int[], T>() {
+                    @Override
+                    public void accept(int[] t, T u) {
+                        t[0] += mapper.applyAsInt(u);
+                    }
+                },
+
+                new Function<int[], Integer>() {
+                    @Override
+                    public Integer apply(int[] value) {
+                        return value[0];
+                    }
+                }
+        );
+    }
     
     /**
      * Returns a {@code Collector} that counts the number of input elements.

--- a/stream/src/main/java/com/annimon/stream/Collectors.java
+++ b/stream/src/main/java/com/annimon/stream/Collectors.java
@@ -338,6 +338,39 @@ public final class Collectors {
                 }
         );
     }
+
+    /**
+     * Returns a {@code Collector} that summing long-valued input elements.
+     *
+     * @param <T> the type of the input elements
+     * @param mapper  the mapping function which extracts value from element to calculate result
+     * @return a {@code Collector}
+     */
+    public static <T> Collector<T, ?, Long> summingLong(final ToLongFunction<? super T> mapper) {
+        return new CollectorsImpl<T, long[], Long>(
+
+                new Supplier<long[]>() {
+                    @Override
+                    public long[] get() {
+                        return new long[] { 0L };
+                    }
+                },
+
+                new BiConsumer<long[], T>() {
+                    @Override
+                    public void accept(long[] t, T u) {
+                        t[0] += mapper.applyAsLong(u);
+                    }
+                },
+
+                new Function<long[], Long>() {
+                    @Override
+                    public Long apply(long[] value) {
+                        return value[0];
+                    }
+                }
+        );
+    }
     
     /**
      * Returns a {@code Collector} that counts the number of input elements.
@@ -346,29 +379,13 @@ public final class Collectors {
      * @return a {@code Collector}
      */
     public static <T> Collector<T, ?, Long> counting() {
-        return new CollectorsImpl<T, Long[], Long>(
-                
-                new Supplier<Long[]>() {
-                    @Override
-                    public Long[] get() {
-                        return new Long[] { 0L };
-                    }
-                },
-                
-                new BiConsumer<Long[], T>() {
-                    @Override
-                    public void accept(Long[] t, T u) {
-                        t[0]++;
-                    }
-                },
-                
-                new Function<Long[], Long>() {
-                    @Override
-                    public Long apply(Long[] value) {
-                        return value[0];
-                    }
-                }
-        );
+        return summingLong(new ToLongFunction<T>() {
+
+            @Override
+            public long applyAsLong(T t) {
+                return 1L;
+            }
+        });
     }
     
     /**

--- a/stream/src/main/java/com/annimon/stream/Collectors.java
+++ b/stream/src/main/java/com/annimon/stream/Collectors.java
@@ -241,34 +241,19 @@ public final class Collectors {
      * 
      * @param <T> the type of the input elements
      * @param mapper  the mapping function which extracts value from element to calculate result
+     * @deprecated  As of release 1.1.3, replaced by
+     *              {@link #averagingDouble(com.annimon.stream.function.ToDoubleFunction)}
      * @return a {@code Collector}
      */
+    @Deprecated
     public static <T> Collector<T, ?, Double> averaging(final Function<? super T, Double> mapper) {
-        return new CollectorsImpl<T, Double[], Double>(
-                
-                new Supplier<Double[]>() {
-                    @Override
-                    public Double[] get() {
-                        return new Double[] { 0d, 0d };
-                    }
-                },
-                
-                new BiConsumer<Double[], T>() {
-                    @Override
-                    public void accept(Double[] t, T u) {
-                        t[0]++; // count
-                        t[1] += mapper.apply(u); // sum
-                    }
-                },
-                
-                new Function<Double[], Double>() {
-                    @Override
-                    public Double apply(Double[] t) {
-                        if (t[0] == 0) return 0d;
-                        return t[1] / t[0];
-                    }
-                }
-        );
+        return averagingDouble(new ToDoubleFunction<T>() {
+
+            @Override
+            public double applyAsDouble(T t) {
+                return mapper.apply(t);
+            }
+        });
     }
 
     /**

--- a/stream/src/main/java/com/annimon/stream/Collectors.java
+++ b/stream/src/main/java/com/annimon/stream/Collectors.java
@@ -465,7 +465,7 @@ public final class Collectors {
     }
     
     /**
-     * Returns a {@code Collector} that reduces the input elements.
+     * Returns a {@code Collector} that reduces input elements.
      * 
      * @param <T> the type of the input elements
      * @param identity  the initial value
@@ -500,7 +500,7 @@ public final class Collectors {
     }
     
     /**
-     * Returns a {@code Collector} that reduces the input elements.
+     * Returns a {@code Collector} that reduces input elements.
      * 
      * @param <T> the type of the input elements
      * @param <R> the type of the output elements
@@ -571,7 +571,7 @@ public final class Collectors {
     }
     
     /**
-     * Returns a {@code Collector} that performs mapping function before accumulation.
+     * Returns a {@code Collector} that performs mapping before accumulation.
      * 
      * @param <T> the type of the input elements
      * @param <U> the result type of mapping function
@@ -602,7 +602,7 @@ public final class Collectors {
     }
 
     /**
-     * Returns a {@code Collector} that performs flat-mapping function before accumulation.
+     * Returns a {@code Collector} that performs flat-mapping before accumulation.
      *
      * @param <T> the type of the input elements
      * @param <U> the result type of flat-mapping function
@@ -645,8 +645,8 @@ public final class Collectors {
      * 
      * @param <T> the type of the input elements
      * @param <A> the accumulation type
-     * @param <IR> the input type of transformation function
-     * @param <OR> the output type of transformation function
+     * @param <IR> the input type of the transformation function
+     * @param <OR> the output type of the transformation function
      * @param c  the input {@code Collector}
      * @param finisher  the final transformation function
      * @return a {@code Collector}

--- a/stream/src/main/java/com/annimon/stream/function/ToDoubleFunction.java
+++ b/stream/src/main/java/com/annimon/stream/function/ToDoubleFunction.java
@@ -4,6 +4,7 @@ package com.annimon.stream.function;
  * Represents a function which produces an double-valued result from input argument.
  *
  * @param <T> the type of the input of the function
+ * @since 1.1.3
  */
 public interface ToDoubleFunction<T> {
 

--- a/stream/src/main/java/com/annimon/stream/function/ToDoubleFunction.java
+++ b/stream/src/main/java/com/annimon/stream/function/ToDoubleFunction.java
@@ -1,0 +1,17 @@
+package com.annimon.stream.function;
+
+/**
+ * Represents a function which produces an double-valued result from input argument.
+ *
+ * @param <T> the type of the input of the function
+ */
+public interface ToDoubleFunction<T> {
+
+    /**
+     * Applies this function to the given argument.
+     * 
+     * @param t  an argument
+     * @return the function result
+     */
+    double applyAsDouble(T t);
+}

--- a/stream/src/main/java/com/annimon/stream/function/ToLongFunction.java
+++ b/stream/src/main/java/com/annimon/stream/function/ToLongFunction.java
@@ -1,0 +1,17 @@
+package com.annimon.stream.function;
+
+/**
+ * Represents a function which produces an long-valued result from input argument.
+ *
+ * @param <T> the type of the input of the function
+ */
+public interface ToLongFunction<T> {
+
+    /**
+     * Applies this function to the given argument.
+     * 
+     * @param t  an argument
+     * @return the function result
+     */
+    long applyAsLong(T t);
+}

--- a/stream/src/main/java/com/annimon/stream/function/ToLongFunction.java
+++ b/stream/src/main/java/com/annimon/stream/function/ToLongFunction.java
@@ -4,6 +4,7 @@ package com.annimon.stream.function;
  * Represents a function which produces an long-valued result from input argument.
  *
  * @param <T> the type of the input of the function
+ * @since 1.1.3
  */
 public interface ToLongFunction<T> {
 

--- a/stream/src/test/java/com/annimon/stream/CollectorsTest.java
+++ b/stream/src/test/java/com/annimon/stream/CollectorsTest.java
@@ -3,6 +3,7 @@ package com.annimon.stream;
 import com.annimon.stream.function.BinaryOperator;
 import com.annimon.stream.function.Function;
 import com.annimon.stream.function.Supplier;
+import com.annimon.stream.function.ToDoubleFunction;
 import com.annimon.stream.function.ToIntFunction;
 import com.annimon.stream.function.ToLongFunction;
 import com.annimon.stream.function.UnaryOperator;
@@ -207,6 +208,25 @@ public class CollectorsTest {
         avg = Stream.of(Integer.MAX_VALUE, Integer.MAX_VALUE)
                 .collect(Collectors.averagingLong(identity));
         assertThat(avg, closeTo(Integer.MAX_VALUE, 0.001));
+    }
+
+    @Test
+    public void testAveragingDouble() {
+        final ToDoubleFunction<Integer> intToDoubleFunction = new ToDoubleFunction<Integer>() {
+            @Override
+            public double applyAsDouble(Integer t) {
+                return t.doubleValue();
+            }
+        };
+        double avg;
+
+        avg = Stream.<Integer>empty()
+                .collect(Collectors.averagingDouble(intToDoubleFunction));
+        assertThat(avg, closeTo(0, 0.001));
+
+        avg = Stream.of(1, 2, 3, 4)
+                .collect(Collectors.averagingDouble(intToDoubleFunction));
+        assertThat(avg, closeTo(2.5, 0.001));
     }
 
     @Test

--- a/stream/src/test/java/com/annimon/stream/CollectorsTest.java
+++ b/stream/src/test/java/com/annimon/stream/CollectorsTest.java
@@ -181,6 +181,26 @@ public class CollectorsTest {
     }
 
     @Test
+    public void testSummingInt() {
+        final ToIntFunction<Integer> identity = new ToIntFunction<Integer>() {
+            @Override
+            public int applyAsInt(Integer t) {
+                return t;
+            }
+        };
+
+        int sum;
+
+        sum = Stream.<Integer>empty()
+                .collect(Collectors.summingInt(identity));
+        assertThat(sum, is(0));
+
+        sum = Stream.of(1, 2, 3, 4)
+                .collect(Collectors.summingInt(identity));
+        assertThat(sum, is(10));
+    }
+
+    @Test
     public void testCounting() {
         long count = Stream.range(0, 20)
                 .collect(Collectors.counting());

--- a/stream/src/test/java/com/annimon/stream/CollectorsTest.java
+++ b/stream/src/test/java/com/annimon/stream/CollectorsTest.java
@@ -179,6 +179,10 @@ public class CollectorsTest {
         avg = Stream.of(1, 2, 3, 4)
                 .collect(Collectors.averagingInt(identity));
         assertThat(avg, closeTo(2.5, 0.001));
+
+        avg = Stream.of(Integer.MAX_VALUE, Integer.MAX_VALUE)
+                .collect(Collectors.averagingInt(identity));
+        assertThat(avg, closeTo(Integer.MAX_VALUE, 0.001));
     }
 
     @Test
@@ -219,6 +223,10 @@ public class CollectorsTest {
         sum = Stream.of(1L, 2L, 3L, 4L)
                 .collect(Collectors.summingLong(identity));
         assertThat(sum, is(10L));
+
+        sum = Stream.of(1L, Long.MAX_VALUE - 1)
+                .collect(Collectors.summingLong(identity));
+        assertThat(sum, is(Long.MAX_VALUE));
     }
 
     @Test

--- a/stream/src/test/java/com/annimon/stream/CollectorsTest.java
+++ b/stream/src/test/java/com/annimon/stream/CollectorsTest.java
@@ -4,6 +4,7 @@ import com.annimon.stream.function.BinaryOperator;
 import com.annimon.stream.function.Function;
 import com.annimon.stream.function.Supplier;
 import com.annimon.stream.function.ToIntFunction;
+import com.annimon.stream.function.ToLongFunction;
 import com.annimon.stream.function.UnaryOperator;
 import static com.annimon.stream.test.hamcrest.CommonMatcher.hasOnlyPrivateConstructors;
 import java.util.Arrays;
@@ -198,6 +199,26 @@ public class CollectorsTest {
         sum = Stream.of(1, 2, 3, 4)
                 .collect(Collectors.summingInt(identity));
         assertThat(sum, is(10));
+    }
+
+    @Test
+    public void testSummingLong() {
+        final ToLongFunction<Long> identity = new ToLongFunction<Long>() {
+            @Override
+            public long applyAsLong(Long t) {
+                return t;
+            }
+        };
+
+        long sum;
+
+        sum = Stream.<Long>empty()
+                .collect(Collectors.summingLong(identity));
+        assertThat(sum, is(0L));
+
+        sum = Stream.of(1L, 2L, 3L, 4L)
+                .collect(Collectors.summingLong(identity));
+        assertThat(sum, is(10L));
     }
 
     @Test

--- a/stream/src/test/java/com/annimon/stream/CollectorsTest.java
+++ b/stream/src/test/java/com/annimon/stream/CollectorsTest.java
@@ -432,6 +432,22 @@ public class CollectorsTest {
     }
 
     @Test
+    public void testFiltering() {
+        List<Integer> list;
+        list = Stream.rangeClosed(1, 6)
+                .collect( Collectors.filtering(Functions.remainder(2), Collectors.<Integer>toList()) );
+        assertThat(list, contains(2, 4, 6));
+
+        list = Stream.rangeClosed(1, 6)
+                .collect( Collectors.filtering(Functions.remainder(20), Collectors.<Integer>toList()) );
+        assertThat(list, is(empty()));
+
+        list = Stream.<Integer>empty()
+                .collect( Collectors.filtering(Functions.remainder(20), Collectors.<Integer>toList()) );
+        assertThat(list, is(empty()));
+    }
+
+    @Test
     public void testMappingSquareIntToString() {
         Function<Integer, String> squareToString = new Function<Integer, String>() {
             @Override

--- a/stream/src/test/java/com/annimon/stream/CollectorsTest.java
+++ b/stream/src/test/java/com/annimon/stream/CollectorsTest.java
@@ -140,6 +140,7 @@ public class CollectorsTest {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void testAveraging() {
         double avg;
 

--- a/stream/src/test/java/com/annimon/stream/CollectorsTest.java
+++ b/stream/src/test/java/com/annimon/stream/CollectorsTest.java
@@ -275,6 +275,26 @@ public class CollectorsTest {
     }
 
     @Test
+    public void testSummingDouble() {
+        final ToDoubleFunction<Double> identity = new ToDoubleFunction<Double>() {
+            @Override
+            public double applyAsDouble(Double t) {
+                return t;
+            }
+        };
+
+        double sum;
+
+        sum = Stream.<Double>empty()
+                .collect(Collectors.summingDouble(identity));
+        assertThat(sum, closeTo(0, 0.001));
+
+        sum = Stream.of(1d, 2d, 3d, 4d)
+                .collect(Collectors.summingDouble(identity));
+        assertThat(sum, closeTo(10, 0.001));
+    }
+
+    @Test
     public void testCounting() {
         long count = Stream.range(0, 20)
                 .collect(Collectors.counting());

--- a/stream/src/test/java/com/annimon/stream/CollectorsTest.java
+++ b/stream/src/test/java/com/annimon/stream/CollectorsTest.java
@@ -139,7 +139,18 @@ public class CollectorsTest {
 
     @Test
     public void testAveraging() {
-        double avg = Stream.of(10, 20, 30, 40)
+        double avg;
+
+        avg = Stream.<Integer>empty()
+                .collect(Collectors.averaging(new Function<Integer, Double>() {
+                    @Override
+                    public Double apply(Integer t) {
+                        return t.doubleValue();
+                    }
+                }));
+        assertThat(avg, closeTo(0, 0.001));
+
+        avg = Stream.of(10, 20, 30, 40)
                 .collect(Collectors.averaging(new Function<Integer, Double>() {
                     @Override
                     public Double apply(Integer value) {

--- a/stream/src/test/java/com/annimon/stream/CollectorsTest.java
+++ b/stream/src/test/java/com/annimon/stream/CollectorsTest.java
@@ -2,6 +2,7 @@ package com.annimon.stream;
 
 import com.annimon.stream.function.BinaryOperator;
 import com.annimon.stream.function.Function;
+import com.annimon.stream.function.IntSupplier;
 import com.annimon.stream.function.Supplier;
 import com.annimon.stream.function.ToDoubleFunction;
 import com.annimon.stream.function.ToIntFunction;
@@ -467,6 +468,41 @@ public class CollectorsTest {
                     Students.GEORGE_LAW_3.getName(),
                     Students.SERGEY_LAW_1.getName()
                 }));
+    }
+
+    @Test
+    public void testFlatMapping() {
+        Function<Integer, Stream<Integer>> repeaterFunction = new Function<Integer, Stream<Integer>>() {
+            @Override
+            public Stream<Integer> apply(final Integer value) {
+                if (value < 0) return null;
+                if (value == 0) return Stream.empty();
+                return IntStream.generate(new IntSupplier() {
+                    @Override
+                    public int getAsInt() {
+                        return value;
+                    }
+                }).limit(value).boxed();
+            }
+        };
+
+        List<Integer> list;
+
+        list = Stream.of(1, 2, 3, 4)
+                .collect( Collectors.flatMapping(repeaterFunction, Collectors.<Integer>toList()) );
+        assertThat(list, contains(1, 2, 2, 3, 3, 3, 4, 4, 4, 4));
+
+        list = Stream.of(-1, -1)
+                .collect( Collectors.flatMapping(repeaterFunction, Collectors.<Integer>toList()) );
+        assertThat(list, is(empty()));
+
+        list = Stream.of(0, 0)
+                .collect( Collectors.flatMapping(repeaterFunction, Collectors.<Integer>toList()) );
+        assertThat(list, is(empty()));
+
+        list = Stream.of(2, 0, 3, -4)
+                .collect( Collectors.flatMapping(repeaterFunction, Collectors.<Integer>toList()) );
+        assertThat(list, contains(2, 2, 3, 3, 3));
     }
 
     @Test

--- a/stream/src/test/java/com/annimon/stream/CollectorsTest.java
+++ b/stream/src/test/java/com/annimon/stream/CollectorsTest.java
@@ -3,6 +3,7 @@ package com.annimon.stream;
 import com.annimon.stream.function.BinaryOperator;
 import com.annimon.stream.function.Function;
 import com.annimon.stream.function.Supplier;
+import com.annimon.stream.function.ToIntFunction;
 import com.annimon.stream.function.UnaryOperator;
 import static com.annimon.stream.test.hamcrest.CommonMatcher.hasOnlyPrivateConstructors;
 import java.util.Arrays;
@@ -145,6 +146,26 @@ public class CollectorsTest {
                         return value / 10d;
                     }
                 }));
+        assertThat(avg, closeTo(2.5, 0.001));
+    }
+
+    @Test
+    public void testAveragingInt() {
+        final ToIntFunction<Integer> identity = new ToIntFunction<Integer>() {
+            @Override
+            public int applyAsInt(Integer t) {
+                return t;
+            }
+        };
+
+        double avg;
+        
+        avg = Stream.<Integer>empty()
+                .collect(Collectors.averagingInt(identity));
+        assertThat(avg, closeTo(0, 0.001));
+
+        avg = Stream.of(1, 2, 3, 4)
+                .collect(Collectors.averagingInt(identity));
         assertThat(avg, closeTo(2.5, 0.001));
     }
 

--- a/stream/src/test/java/com/annimon/stream/CollectorsTest.java
+++ b/stream/src/test/java/com/annimon/stream/CollectorsTest.java
@@ -186,6 +186,30 @@ public class CollectorsTest {
     }
 
     @Test
+    public void testAveragingLong() {
+        final ToLongFunction<Integer> identity = new ToLongFunction<Integer>() {
+            @Override
+            public long applyAsLong(Integer t) {
+                return t;
+            }
+        };
+
+        double avg;
+
+        avg = Stream.<Integer>empty()
+                .collect(Collectors.averagingLong(identity));
+        assertThat(avg, closeTo(0, 0.001));
+
+        avg = Stream.of(1, 2, 3, 4)
+                .collect(Collectors.averagingLong(identity));
+        assertThat(avg, closeTo(2.5, 0.001));
+
+        avg = Stream.of(Integer.MAX_VALUE, Integer.MAX_VALUE)
+                .collect(Collectors.averagingLong(identity));
+        assertThat(avg, closeTo(Integer.MAX_VALUE, 0.001));
+    }
+
+    @Test
     public void testSummingInt() {
         final ToIntFunction<Integer> identity = new ToIntFunction<Integer>() {
             @Override


### PR DESCRIPTION
 - Added summingInt, summingLong, summingDouble collectors
 - Added averagingInt, averagingLong, averagingDouble collectors
 - Added ToLongFunction and ToDoubleFunction interfaces
 - Collectors.counting now uses summingLong to avoid unnecessary boxing
 - Collectors.averaging now deprecated and uses averagingDouble internally, also fixed NaN result for empty stream
 - Added flatMapping and filtering collectors, which introduced in Java 9