### PR TITLE
Update comment on distinct() method in Stream.java

### DIFF
--- a/stream/src/main/java/com/annimon/stream/Stream.java
+++ b/stream/src/main/java/com/annimon/stream/Stream.java
@@ -748,7 +748,7 @@ public class Stream<T> {
     }
 
     /**
-     * Returns {@code Stream} with distinct elements (as determinated by {@code equals} method).
+     * Returns {@code Stream} with distinct elements (as determinated by {@code hashCode} method).
      *
      * <p>This is a stateful intermediate operation.
      *


### PR DESCRIPTION
The comment describing the `distinct()` method on a `Stream` mentioned that it determines uniqueness by using the `equals()` method.  The implementation of `distinct()` however, adds elements to a set and returns the result of the set.  In so doing, the `distinct()` method actually determines uniqueness as a result of `hashCode()`, rather than `equals()`.