### PR TITLE
Add Exceptional.of(Throwable) factory method

### DIFF
--- a/stream/src/main/java/com/annimon/stream/Exceptional.java
+++ b/stream/src/main/java/com/annimon/stream/Exceptional.java
@@ -30,7 +30,7 @@ import com.annimon.stream.function.ThrowableSupplier;
  * @param <T> the type of the inner value
  */
 public class Exceptional<T> {
-    
+
     /**
      * Returns an {@code Exceptional} with value provided by given {@code ThrowableSupplier} function.
      * 
@@ -44,6 +44,16 @@ public class Exceptional<T> {
         } catch (Throwable throwable) {
             return new Exceptional<T>(null, throwable);
         }
+    }
+
+    /**
+     * Returns an {@code Exceptional} with throwable already set.
+     *
+     * @param <T> the type of value
+     * @return an {@code Exceptional}
+     */
+    public static <T> Exceptional<T> of(Throwable throwable) {
+        return new Exceptional<T>(null, throwable);
     }
     
     private final T value;

--- a/stream/src/test/java/com/annimon/stream/ExceptionalTest.java
+++ b/stream/src/test/java/com/annimon/stream/ExceptionalTest.java
@@ -56,6 +56,11 @@ public class ExceptionalTest {
         assertThat(throwable, instanceOf(IOException.class));
     }
 
+    @Test
+    public void testGetExceptionFromAlreadySuppliedThrowable() {
+        Throwable throwable = Exceptional.of(new IOException()).getException();
+        assertThat(throwable, instanceOf(IOException.class));
+    }
 
     @Test
     public void testGetOrThrowWithoutException() throws Throwable {


### PR DESCRIPTION
Currently, if I already have a throwable that I would like to wrap using `Exceptional` I have to rethrow it like this: 
```
Exceptional.of(() -> {
            throw throwable;
        })
```

Adding a factory method that accepts `Throwable` instead simplifies the code:
```
Exceptional.of(throwable)
```