### PR TITLE
ComparatorCompat improvements

### DIFF
--- a/stream/src/main/java/com/annimon/stream/ComparatorCompat.java
+++ b/stream/src/main/java/com/annimon/stream/ComparatorCompat.java
@@ -51,6 +51,46 @@ public final class ComparatorCompat<T> implements Comparator<T> {
     }
 
     /**
+     * Returns a comparator that reverses the order of the specified comparator.
+     * If the specified comparator is {@code null}, this method is equivalent
+     * to {@link #reverseOrder()}.
+     *
+     * @param <T> the type of the objects compared by the comparator
+     * @param comparator  a comparator to be reversed
+     * @return a comparator
+     * @see Collections#reverseOrder(java.util.Comparator)
+     * @throws NullPointerException if {@code comparator} is null
+     */
+    public static <T> Comparator<T> reversed(Comparator<T> comparator) {
+        return Collections.reverseOrder(comparator);
+    }
+
+    /**
+     * Returns a comparator that uses {@code c2} comparator
+     * if {@code c1} comparator considers two elements equal.
+     *
+     * @param <T> the type of the objects compared by the comparators
+     * @param c1  a first comparator
+     * @param c2  a second comparator
+     * @return a comparator
+     * @throws NullPointerException if {@code c1} or {@code c2} is null
+     */
+    public static <T> Comparator<T> thenComparing(
+            final Comparator<? super T> c1,
+            final Comparator<? super T> c2) {
+        Objects.requireNonNull(c1);
+        Objects.requireNonNull(c2);
+        return new Comparator<T>() {
+
+            @Override
+            public int compare(T t1, T t2) {
+                final int result = c1.compare(t1, t2);
+                return (result != 0) ? result : c2.compare(t1, t2);
+            }
+        };
+    }
+
+    /**
      * Returns a comparator that uses a function that extracts a sort key
      * to be compared with the specified comparator.
      *
@@ -235,6 +275,18 @@ public final class ComparatorCompat<T> implements Comparator<T> {
         });
     }
 
+    /**
+     * Allows to build comparators with method chaining.
+     *
+     * @param <T> the type of the objects compared by the comparator
+     * @param comparator  the comparator to be chained
+     * @return a {@code Chain} instance
+     */
+    public static <T> ComparatorCompat<T> chain(Comparator<T> comparator) {
+        return new ComparatorCompat<T>(comparator);
+    }
+
+
     private final Comparator<? super T> comparator;
 
     public ComparatorCompat(Comparator<? super T> comparator) {
@@ -329,6 +381,17 @@ public final class ComparatorCompat<T> implements Comparator<T> {
      */
     public ComparatorCompat<T> thenComparingDouble(ToDoubleFunction<? super T> keyExtractor) {
         return thenComparing(comparingDouble(keyExtractor));
+    }
+
+    /**
+     * Returns a chained {@code Comparator}.
+     *
+     * @deprecated  As of release 1.1.7, it is unnecessary to call this method.
+     * @return a comparator
+     */
+    @SuppressWarnings("unchecked")
+    public Comparator<T> comparator() {
+        return (Comparator<T>) comparator;
     }
 
     @Override

--- a/stream/src/test/java/com/annimon/stream/ComparatorCompatTest.java
+++ b/stream/src/test/java/com/annimon/stream/ComparatorCompatTest.java
@@ -35,8 +35,9 @@ public class ComparatorCompatTest {
     public void testReversedComparator() {
         int[] expected = {1, -2, 4, -8, 16};
         IntStream stream = IntStream.of(-8, -2, 1, 4, 16)
-                .sorted(new ComparatorCompat<Integer>(Functions.descendingAbsoluteOrder())
-                        .reversed());
+                .sorted(ComparatorCompat.reversed(
+                        Functions.descendingAbsoluteOrder()
+                ));
         assertThat(stream.toArray(), is(expected));
     }
 
@@ -44,8 +45,9 @@ public class ComparatorCompatTest {
     public void testThenComparing() {
         int[] expected = {16, -16, 4, -4, -2, 1};
         IntStream stream = IntStream.of(-16, -4, -2, 1, 4, 16)
-                .sorted(new ComparatorCompat<Integer>(Functions.descendingAbsoluteOrder())
-                        .thenComparing(ComparatorCompat.<Integer>reverseOrder()
+                .sorted(ComparatorCompat.thenComparing(
+                        Functions.descendingAbsoluteOrder(),
+                        ComparatorCompat.<Integer>reverseOrder()
                 ));
         assertThat(stream.toArray(), is(expected));
     }
@@ -248,6 +250,18 @@ public class ComparatorCompatTest {
                 .reversed()
                 .thenComparing(Students.course)
                 .thenComparing(Students.speciality);
+        testStudentComparator(comparator);
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    public void testChain_NameReversedThenCourseThenSpeciality_Deprecation() {
+        Comparator<Student> comparator = ComparatorCompat
+                .chain(ComparatorCompat.comparing(Students.studentName))
+                .reversed()
+                .thenComparing(Students.course)
+                .thenComparing(Students.speciality)
+                .comparator();
         testStudentComparator(comparator);
     }
 

--- a/stream/src/test/java/com/annimon/stream/ComparatorCompatTest.java
+++ b/stream/src/test/java/com/annimon/stream/ComparatorCompatTest.java
@@ -8,18 +8,12 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import org.junit.Test;
-import static com.annimon.stream.test.hamcrest.CommonMatcher.hasOnlyPrivateConstructors;
 import static com.annimon.stream.test.hamcrest.StreamMatcher.assertElements;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
 public class ComparatorCompatTest {
-
-    @Test
-    public void testPrivateConstructor() throws Exception {
-        assertThat(ComparatorCompat.class, hasOnlyPrivateConstructors());
-    }
 
     @Test
     public void testNaturalOrder() {
@@ -41,9 +35,8 @@ public class ComparatorCompatTest {
     public void testReversedComparator() {
         int[] expected = {1, -2, 4, -8, 16};
         IntStream stream = IntStream.of(-8, -2, 1, 4, 16)
-                .sorted(ComparatorCompat.reversed(
-                        Functions.descendingAbsoluteOrder()
-                ));
+                .sorted(new ComparatorCompat<Integer>(Functions.descendingAbsoluteOrder())
+                        .reversed());
         assertThat(stream.toArray(), is(expected));
     }
 
@@ -51,9 +44,8 @@ public class ComparatorCompatTest {
     public void testThenComparing() {
         int[] expected = {16, -16, 4, -4, -2, 1};
         IntStream stream = IntStream.of(-16, -4, -2, 1, 4, 16)
-                .sorted(ComparatorCompat.thenComparing(
-                        Functions.descendingAbsoluteOrder(),
-                        ComparatorCompat.<Integer>reverseOrder()
+                .sorted(new ComparatorCompat<Integer>(Functions.descendingAbsoluteOrder())
+                        .thenComparing(ComparatorCompat.<Integer>reverseOrder()
                 ));
         assertThat(stream.toArray(), is(expected));
     }
@@ -178,9 +170,8 @@ public class ComparatorCompatTest {
     @Test
     public void testChain_CourseReversed() {
         Comparator<Student> comparator = ComparatorCompat
-                .chain(ComparatorCompat.comparing(Students.course))
-                .reversed()
-                .comparator();
+                .comparing(Students.course)
+                .reversed();
 
         List<Student> input = Arrays.asList(
                 Students.MARIA_CS_1,
@@ -199,9 +190,8 @@ public class ComparatorCompatTest {
     @Test
     public void testChain_CourseThenName() {
         Comparator<Student> comparator = ComparatorCompat
-                .chain(ComparatorCompat.comparing(Students.course))
-                .thenComparing(Students.studentName)
-                .comparator();
+                .comparing(Students.course)
+                .thenComparing(Students.studentName);
 
         List<Student> input = Arrays.asList(
                 Students.MARIA_CS_1,
@@ -222,15 +212,14 @@ public class ComparatorCompatTest {
     @Test
     public void testChain_SpecialityThenCourseThenName() {
         Comparator<Student> comparator = ComparatorCompat
-                .chain(ComparatorCompat.comparing(Students.speciality))
+                .comparing(Students.speciality)
                 .thenComparingInt(new ToIntFunction<Student>() {
                     @Override
                     public int applyAsInt(Student student) {
                         return student.getCourse();
                     }
                 })
-                .thenComparing(Students.studentName)
-                .comparator();
+                .thenComparing(Students.studentName);
 
         List<Student> input = Arrays.asList(
                 Students.STEVE_CS_4,
@@ -255,18 +244,17 @@ public class ComparatorCompatTest {
     @Test
     public void testChain_NameReversedThenCourseThenSpeciality() {
         Comparator<Student> comparator = ComparatorCompat
-                .chain(ComparatorCompat.comparing(Students.studentName))
+                .comparing(Students.studentName)
                 .reversed()
                 .thenComparing(Students.course)
-                .thenComparing(Students.speciality)
-                .comparator();
+                .thenComparing(Students.speciality);
         testStudentComparator(comparator);
     }
 
     @Test
     public void testChain_NameReversedThenCourseThenSpecialityDoubleReversed() {
         Comparator<Student> comparator = ComparatorCompat
-                .chain(ComparatorCompat.comparing(Students.studentName))
+                .comparing(Students.studentName)
                 .thenComparing(ComparatorCompat.<Student>reverseOrder())
                 .thenComparingLong(new ToLongFunction<Student>() {
                     @Override
@@ -275,15 +263,14 @@ public class ComparatorCompatTest {
                     }
                 })
                 .thenComparing(Students.speciality, ComparatorCompat.<String>reverseOrder())
-                .reversed()
-                .comparator();
+                .reversed();
         testStudentComparator(comparator);
     }
 
     @Test
     public void testChain_NameReversedThenCourseThenSpeciality2() {
         Comparator<Student> comparator = ComparatorCompat
-                .chain(ComparatorCompat.comparing(Students.studentName))
+                .comparing(Students.studentName)
                 .reversed()
                 .thenComparingDouble(new ToDoubleFunction<Student>() {
                     @Override
@@ -291,8 +278,7 @@ public class ComparatorCompatTest {
                         return student.getCourse() / 0.001;
                     }
                 })
-                .thenComparing(Students.speciality)
-                .comparator();
+                .thenComparing(Students.speciality);
         testStudentComparator(comparator);
     }
 

--- a/stream/src/test/java/com/annimon/stream/Student.java
+++ b/stream/src/test/java/com/annimon/stream/Student.java
@@ -42,10 +42,9 @@ public final class Student implements Comparable<Student> {
     @Override
     public int compareTo(Student o) {
         return ComparatorCompat
-                .chain(ComparatorCompat.comparing(Students.studentName))
+                .comparing(Students.studentName)
                 .thenComparing(Students.speciality)
                 .thenComparing(Students.course)
-                .comparator()
                 .compare(this, o);
     }
 

--- a/stream/src/test/java/com/annimon/stream/doublestreamtests/FilterTest.java
+++ b/stream/src/test/java/com/annimon/stream/doublestreamtests/FilterTest.java
@@ -3,6 +3,7 @@ package com.annimon.stream.doublestreamtests;
 import com.annimon.stream.DoubleStream;
 import com.annimon.stream.Functions;
 import com.annimon.stream.function.DoublePredicate;
+import java.util.NoSuchElementException;
 import org.junit.Test;
 import static com.annimon.stream.test.hamcrest.DoubleStreamMatcher.assertElements;
 import static com.annimon.stream.test.hamcrest.DoubleStreamMatcher.assertIsEmpty;
@@ -22,5 +23,13 @@ public final class FilterTest {
         DoubleStream.of(0.012, -10)
                 .filter(predicate)
                 .custom(assertIsEmpty());
+    }
+
+    @Test(expected = NoSuchElementException.class)
+    public void testFilterIteratorNextOnEmpty() {
+        DoubleStream.empty()
+                .filter(Functions.greaterThan(Math.PI))
+                .iterator()
+                .next();
     }
 }

--- a/stream/src/test/java/com/annimon/stream/intstreamtests/FilterTest.java
+++ b/stream/src/test/java/com/annimon/stream/intstreamtests/FilterTest.java
@@ -8,6 +8,7 @@ import com.annimon.stream.function.IntUnaryOperator;
 import com.annimon.stream.test.hamcrest.StreamMatcher;
 import java.util.Arrays;
 import java.util.List;
+import java.util.NoSuchElementException;
 import org.junit.Test;
 import static com.annimon.stream.test.hamcrest.IntStreamMatcher.assertElements;
 import static org.hamcrest.Matchers.arrayContaining;
@@ -57,5 +58,13 @@ public final class FilterTest {
                 .custom(StreamMatcher.assertElements(contains(
                         "0", "2", "4"
                 )));
+    }
+
+    @Test(expected = NoSuchElementException.class)
+    public void testFilterIteratorNextOnEmpty() {
+        IntStream.empty()
+                .filter(Functions.remainderInt(2))
+                .iterator()
+                .next();
     }
 }

--- a/stream/src/test/java/com/annimon/stream/longstreamtests/FilterTest.java
+++ b/stream/src/test/java/com/annimon/stream/longstreamtests/FilterTest.java
@@ -3,6 +3,7 @@ package com.annimon.stream.longstreamtests;
 import com.annimon.stream.Functions;
 import com.annimon.stream.LongStream;
 import com.annimon.stream.function.LongPredicate;
+import java.util.NoSuchElementException;
 import org.junit.Test;
 import static com.annimon.stream.test.hamcrest.LongStreamMatcher.assertElements;
 import static com.annimon.stream.test.hamcrest.LongStreamMatcher.assertIsEmpty;
@@ -22,5 +23,13 @@ public final class FilterTest {
         LongStream.of(12, -10)
                 .filter(predicate)
                 .custom(assertIsEmpty());
+    }
+
+    @Test(expected = NoSuchElementException.class)
+    public void testFilterIteratorNextOnEmpty() {
+        LongStream.empty()
+                .filter(Functions.remainderLong(2))
+                .iterator()
+                .next();
     }
 }


### PR DESCRIPTION
As suggested in #109, it would be great to use comparators chaining with direct inheritance. This pull request breaks **binary** compatibility.  
`ComparatorCompat` now parameterized and implements `Comparator` interface. All static methods now returns `ComparatorCompat` instead of `Comparator`.

`ComparatorCompat.comparator` marks as deprecated. If you're using comparators chaining, here is an example how to make your code great again:

```java
// Before
comparator = ComparatorCompat
        .chain(ComparatorCompat.naturalOrder())
        .comparing(...)
        .reversed()
        .comparator();

// After
comparator = ComparatorCompat.naturalOrder()
        .comparing(...)
        .reversed();
```


```java
// Before
comparator = ComparatorCompat
        .chain(String.CASE_INSENSITIVE_ORDER)
        .thenComparing(...)
        .comparator();

// After
comparator = ComparatorCompat
        .chain(String.CASE_INSENSITIVE_ORDER)
        .thenComparing(...);
// Or
comparator = new ComparatorCompat<String>(String.CASE_INSENSITIVE_ORDER)
        .thenComparing(...);
```

I apologize for the inconvenience and hope that these changes will make your code cleaner :pray: 