### PR TITLE
Support for Code Points stream

### DIFF
--- a/stream/src/main/java/com/annimon/stream/Stream.java
+++ b/stream/src/main/java/com/annimon/stream/Stream.java
@@ -6,6 +6,7 @@ import com.annimon.stream.internal.Operators;
 import com.annimon.stream.internal.Params;
 import com.annimon.stream.iterator.IndexedIterator;
 import com.annimon.stream.iterator.LazyIterator;
+import com.annimon.stream.iterator.PrimitiveIterator;
 import com.annimon.stream.operator.*;
 import java.io.Closeable;
 import java.util.ArrayList;
@@ -87,6 +88,47 @@ public class Stream<T> implements Closeable {
             return Stream.<T>empty();
         }
         return new Stream<T>(new ObjArray<T>(elements));
+    }
+
+    /**
+     * Creates a {@code Stream<Integer>} of code point values from the given sequence.
+     * Any surrogate pairs encountered in the sequence are combined as if by {@linkplain
+     * Character#toCodePoint Character.toCodePoint} and the result is passed to the stream.
+     * Any other code units, including ordinary BMP characters, unpaired surrogates, and
+     * undefined code units, are zero-extended to {@code int} values which are then
+     * passed to the stream.
+     *
+     * @param charSequence the sequence where to get all code points values.
+     * @return the new stream
+     */
+    public static Stream<Integer> ofCodePoints(final CharSequence charSequence) {
+        return IntStream.of(new PrimitiveIterator.OfInt() {
+            int current = 0;
+
+            @Override
+            public boolean hasNext() {
+                return current < charSequence.length();
+            }
+
+            @Override
+            public int nextInt() {
+                final int length = charSequence.length();
+
+                if (current >= length) {
+                    throw new NoSuchElementException();
+                }
+                char nextChar = charSequence.charAt(current++);
+
+                if (Character.isHighSurrogate(nextChar) && current < length) {
+                    char currentChar = charSequence.charAt(current);
+                    if (Character.isLowSurrogate(currentChar)) {
+                        current++;
+                        return Character.toCodePoint(nextChar, currentChar);
+                    }
+                }
+                return nextChar;
+            }
+        }).boxed();
     }
 
     /**

--- a/stream/src/test/java/com/annimon/stream/streamtests/OfCodePointTest.java
+++ b/stream/src/test/java/com/annimon/stream/streamtests/OfCodePointTest.java
@@ -1,0 +1,42 @@
+package com.annimon.stream.streamtests;
+
+import com.annimon.stream.Collectors;
+import com.annimon.stream.Stream;
+import com.annimon.stream.function.Function;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class OfCodePointTest {
+
+    @Test
+    public void testStreamOfCommonSequence() {
+        String input = "hi";
+
+        String result = Stream.ofCodePoints(input)
+                .map(new Function<Integer, String>() {
+                    @Override
+                    public String apply(Integer i) {
+                        return String.valueOf(Character.toChars(i));
+                    }
+                }).collect(Collectors.joining());
+
+        assertThat(input, is(result));
+    }
+
+    @Test
+    public void testStreamOfSequenceHavingFourBytesEmoji() {
+        String input = "This is a emoji \uD83D\uDCA9!";
+
+        String result = Stream.ofCodePoints(input)
+                .map(new Function<Integer, String>() {
+                    @Override
+                    public String apply(Integer i) {
+                        return String.valueOf(Character.toChars(i));
+                    }
+                }).collect(Collectors.joining());
+
+        assertThat(input, is(result));
+    }
+}


### PR DESCRIPTION
I had the needed to generate a `Stream<Integer>` from all code points inside of a `CharSequence`. I realized Java 8 has support only calling `charSequence.codePoints()` so I ported the Java 8 code into your library and this is the result (I'm actually using it).

I've added a couple of simple tests to verify the correct behavior too.