### PR TITLE
Add ofNullable API for Optional primitive types

### DIFF
--- a/stream/src/main/java/com/annimon/stream/OptionalBoolean.java
+++ b/stream/src/main/java/com/annimon/stream/OptionalBoolean.java
@@ -40,6 +40,15 @@ public final class OptionalBoolean {
         return value ? TRUE : FALSE;
     }
 
+    /**
+     * Returns an {@code OptionalBoolean} with the specified value, or empty {@code OptionalBoolean} if value is null.
+     *
+     * @param value  the value which can be null
+     * @return an {@code OptionalBoolean}
+     */
+    public static OptionalBoolean ofNullable(Boolean value) {
+        return value == null ? EMPTY : of(value);
+    }
 
     private final boolean isPresent;
     private final boolean value;

--- a/stream/src/main/java/com/annimon/stream/OptionalDouble.java
+++ b/stream/src/main/java/com/annimon/stream/OptionalDouble.java
@@ -41,6 +41,15 @@ public final class OptionalDouble {
         return new OptionalDouble(value);
     }
 
+    /**
+     * Returns an {@code OptionalDouble} with the specified value, or empty {@code OptionalDouble} if value is null.
+     *
+     * @param value the value which can be null
+     * @return an {@code OptionalDouble}
+     */
+    public static OptionalDouble ofNullable(Double value) {
+        return value == null ? EMPTY : new OptionalDouble(value);
+    }
 
     private final boolean isPresent;
     private final double value;

--- a/stream/src/main/java/com/annimon/stream/OptionalInt.java
+++ b/stream/src/main/java/com/annimon/stream/OptionalInt.java
@@ -68,6 +68,16 @@ public final class OptionalInt {
     }
 
     /**
+     * Returns an {@code OptionalInt} with the specified value, or empty {@code OptionalInt} if value is null.
+     *
+     * @param value the value which can be null
+     * @return an {@code OptionalInt}
+     */
+    public static OptionalInt ofNullable(Integer value) {
+        return value == null ? EMPTY : new OptionalInt(value);
+    }
+
+    /**
      * If a value is present in this {@code OptionalInt}, returns the value,
      * otherwise throws {@code NoSuchElementException}.
      *

--- a/stream/src/main/java/com/annimon/stream/OptionalLong.java
+++ b/stream/src/main/java/com/annimon/stream/OptionalLong.java
@@ -40,6 +40,15 @@ public final class OptionalLong {
         return new OptionalLong(value);
     }
 
+    /**
+     * Returns an {@code OptionalLong} with the specified value, or empty {@code OptionalLong} if value is null.
+     *
+     * @param value the value which can be null
+     * @return an {@code OptionalLong}
+     */
+    public static OptionalLong ofNullable(Long value) {
+        return value == null ? EMPTY : new OptionalLong(value);
+    }
 
     private final boolean isPresent;
     private final long value;

--- a/stream/src/test/java/com/annimon/stream/OptionalBooleanTest.java
+++ b/stream/src/test/java/com/annimon/stream/OptionalBooleanTest.java
@@ -26,6 +26,16 @@ public class OptionalBooleanTest {
         assertTrue(value);
     }
 
+    @Test
+    public void testOfNullableWithPresentValue() {
+        assertThat(OptionalBoolean.ofNullable(true), hasValue(true));
+    }
+
+    @Test
+    public void testOfNullableWithAbsentValue() {
+        assertThat(OptionalBoolean.ofNullable(null), isEmpty());
+    }
+
     @Test(expected = NoSuchElementException.class)
     public void testGetOnEmptyOptional() {
         OptionalBoolean.empty().getAsBoolean();

--- a/stream/src/test/java/com/annimon/stream/OptionalDoubleTest.java
+++ b/stream/src/test/java/com/annimon/stream/OptionalDoubleTest.java
@@ -29,6 +29,16 @@ public class OptionalDoubleTest {
         assertThat(value, closeTo(10.123, 0.0001));
     }
 
+    @Test
+    public void testOfNullableWithPresentValue() {
+        assertThat(OptionalDouble.ofNullable(10.123), hasValueThat(closeTo(10.123, 0.0001)));
+    }
+
+    @Test
+    public void testOfNullableWithAbsentValue() {
+        assertThat(OptionalDouble.ofNullable(null), isEmpty());
+    }
+
     @Test(expected = NoSuchElementException.class)
     public void testGetOnEmptyOptional() {
         OptionalDouble.empty().getAsDouble();

--- a/stream/src/test/java/com/annimon/stream/OptionalIntTest.java
+++ b/stream/src/test/java/com/annimon/stream/OptionalIntTest.java
@@ -31,6 +31,16 @@ public class OptionalIntTest {
         assertEquals(10, value);
     }
 
+    @Test
+    public void testOfNullableWithPresentValue() {
+        assertThat(OptionalInt.ofNullable(10), hasValue(10));
+    }
+
+    @Test
+    public void testOfNullableWithAbsentValue() {
+        assertThat(OptionalInt.ofNullable(null), isEmpty());
+    }
+
     @Test(expected = NoSuchElementException.class)
     public void testGetOnEmptyOptional() {
         OptionalInt.empty().getAsInt();

--- a/stream/src/test/java/com/annimon/stream/OptionalLongTest.java
+++ b/stream/src/test/java/com/annimon/stream/OptionalLongTest.java
@@ -28,6 +28,16 @@ public class OptionalLongTest {
         assertEquals(10, value);
     }
 
+    @Test
+    public void testOfNullableWithPresentValue() {
+        assertThat(OptionalLong.ofNullable(10L), hasValue(10L));
+    }
+
+    @Test
+    public void testOfNullableWithAbsentValue() {
+        assertThat(OptionalLong.ofNullable(null), isEmpty());
+    }
+
     @Test(expected = NoSuchElementException.class)
     public void testGetOnEmptyOptional() {
         OptionalLong.empty().getAsLong();


### PR DESCRIPTION
I've found myself repeating the ternary "empty() or of()" routine when integrating with external boxed primitives recently, so this PR introduces `ofNullable` for `OptionalX` primitive types.