### PR TITLE
Add nullability annotations

### DIFF
--- a/stream/build.gradle
+++ b/stream/build.gradle
@@ -20,6 +20,7 @@ repositories {
 }
 
 dependencies {
+    compileOnly 'org.jetbrains:annotations-java5:17.0.0'
     testImplementation group: 'junit', name: 'junit', version: '4.12'
     testImplementation 'org.hamcrest:hamcrest-library:1.3'
     testImplementation project(':streamTest')

--- a/stream/pom.xml
+++ b/stream/pom.xml
@@ -91,6 +91,11 @@
   
   <dependencies>
     <dependency>
+      <groupId>org.jetbrains</groupId>
+      <artifactId>annotations-java5</artifactId>
+      <version>17.0.0</version>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.12</version>

--- a/stream/src/main/java/com/annimon/stream/Collectors.java
+++ b/stream/src/main/java/com/annimon/stream/Collectors.java
@@ -10,6 +10,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Common implementations of {@code Collector} interface.
@@ -43,14 +45,16 @@ public final class Collectors {
      * @param collectionSupplier  a supplier function that provides new collection
      * @return a {@code Collector}
      */
-    public static <T, R extends Collection<T>> Collector<T, ?, R> toCollection(Supplier<R> collectionSupplier) {
+    @NotNull
+    public static <T, R extends Collection<T>> Collector<T, ?, R> toCollection(
+            @NotNull Supplier<R> collectionSupplier) {
         return new CollectorsImpl<T, R, R>(
 
                 collectionSupplier,
 
                 new BiConsumer<R, T>() {
                     @Override
-                    public void accept(R t, T u) {
+                    public void accept(@NotNull R t, T u) {
                         t.add(u);
                     }
                 }
@@ -63,10 +67,12 @@ public final class Collectors {
      * @param <T> the type of the input elements
      * @return a {@code Collector}
      */
+    @NotNull
     public static <T> Collector<T, ?, List<T>> toList() {
         return new CollectorsImpl<T, List<T>, List<T>>(
 
                 new Supplier<List<T>>() {
+                    @NotNull
                     @Override
                     public List<T> get() {
                         return new ArrayList<T>();
@@ -75,7 +81,7 @@ public final class Collectors {
 
                 new BiConsumer<List<T>, T>() {
                     @Override
-                    public void accept(List<T> t, T u) {
+                    public void accept(@NotNull List<T> t, T u) {
                         t.add(u);
                     }
                 }
@@ -92,11 +98,13 @@ public final class Collectors {
      * @return a {@code Collector}
      * @since 1.2.0
      */
+    @NotNull
     public static <T> Collector<T, ?, List<T>> toUnmodifiableList() {
         return Collectors.collectingAndThen(Collectors.<T>toList(), new UnaryOperator<List<T>>() {
 
+            @NotNull
             @Override
-            public List<T> apply(List<T> list) {
+            public List<T> apply(@NotNull List<T> list) {
                 Objects.requireNonNullElements(list);
                 return Collections.unmodifiableList(list);
             }
@@ -109,10 +117,12 @@ public final class Collectors {
      * @param <T> the type of the input elements
      * @return a {@code Collector}
      */
+    @NotNull
     public static <T> Collector<T, ?, Set<T>> toSet() {
         return new CollectorsImpl<T, Set<T>, Set<T>>(
 
                 new Supplier<Set<T>>() {
+                    @NotNull
                     @Override
                     public Set<T> get() {
                         return new HashSet<T>();
@@ -121,7 +131,7 @@ public final class Collectors {
 
                 new BiConsumer<Set<T>, T>() {
                     @Override
-                    public void accept(Set<T> set, T t) {
+                    public void accept(@NotNull Set<T> set, T t) {
                         set.add(t);
                     }
                 }
@@ -139,11 +149,13 @@ public final class Collectors {
      * @return a {@code Collector}
      * @since 1.2.0
      */
+    @NotNull
     public static <T> Collector<T, ?, Set<T>> toUnmodifiableSet() {
         return Collectors.collectingAndThen(Collectors.<T>toSet(), new UnaryOperator<Set<T>>() {
 
+            @NotNull
             @Override
-            public Set<T> apply(Set<T> set) {
+            public Set<T> apply(@NotNull Set<T> set) {
                 Objects.requireNonNullElements(set);
                 return Collections.unmodifiableSet(set);
             }
@@ -163,8 +175,9 @@ public final class Collectors {
      * @since 1.1.3
      * @see #toMap(Function, Function, BinaryOperator)
      */
+    @NotNull
     public static <T, K> Collector<T, ?, Map<K, T>> toMap(
-            final Function<? super T, ? extends K> keyMapper) {
+            @NotNull final Function<? super T, ? extends K> keyMapper) {
         return Collectors.<T, K, T>toMap(keyMapper, UnaryOperator.Util.<T>identity());
     }
 
@@ -182,9 +195,10 @@ public final class Collectors {
      * @return a {@code Collector}
      * @see #toMap(Function, Function, BinaryOperator)
      */
+    @NotNull
     public static <T, K, V> Collector<T, ?, Map<K, V>> toMap(
-            final Function<? super T, ? extends K> keyMapper,
-            final Function<? super T, ? extends V> valueMapper) {
+            @NotNull final Function<? super T, ? extends K> keyMapper,
+            @NotNull final Function<? super T, ? extends V> valueMapper) {
         return Collectors.<T, K, V, Map<K, V>>toMap(keyMapper, valueMapper,
                 Collectors.<K, V>hashMapSupplier());
     }
@@ -205,10 +219,11 @@ public final class Collectors {
      * @return a {@code Collector}
      * @see #toMap(Function, Function, BinaryOperator, Supplier)
      */
+    @NotNull
     public static <T, K, V, M extends Map<K, V>> Collector<T, ?, M> toMap(
-            final Function<? super T, ? extends K> keyMapper,
-            final Function<? super T, ? extends V> valueMapper,
-            final Supplier<M> mapFactory) {
+            @NotNull final Function<? super T, ? extends K> keyMapper,
+            @NotNull final Function<? super T, ? extends V> valueMapper,
+            @NotNull final Supplier<M> mapFactory) {
         return new CollectorsImpl<T, M, M>(
 
                 mapFactory,
@@ -248,9 +263,10 @@ public final class Collectors {
      * @see #toUnmodifiableMap(Function, Function, BinaryOperator)
      * @since 1.2.0
      */
+    @NotNull
     public static <T, K, V> Collector<T, ?, Map<K, V>> toUnmodifiableMap(
-            final Function<? super T, ? extends K> keyMapper,
-            final Function<? super T, ? extends V> valueMapper) {
+            @NotNull final Function<? super T, ? extends K> keyMapper,
+            @NotNull final Function<? super T, ? extends V> valueMapper) {
         return Collectors.collectingAndThen(
                 Collectors.<T, K, V>toMap(keyMapper, valueMapper),
                 Collectors.<K, V>toUnmodifiableMapConverter());
@@ -272,10 +288,11 @@ public final class Collectors {
      * @return a {@code Collector}
      * @since 1.2.0
      */
+    @NotNull
     public static <T, K, V> Collector<T, ?, Map<K, V>> toMap(
-            final Function<? super T, ? extends K> keyMapper,
-            final Function<? super T, ? extends V> valueMapper,
-            final BinaryOperator<V> mergeFunction) {
+            @NotNull final Function<? super T, ? extends K> keyMapper,
+            @NotNull final Function<? super T, ? extends V> valueMapper,
+            @NotNull final BinaryOperator<V> mergeFunction) {
         return Collectors.<T, K, V, Map<K, V>>toMap(
                 keyMapper, valueMapper, mergeFunction,
                 Collectors.<K, V>hashMapSupplier());
@@ -299,18 +316,19 @@ public final class Collectors {
      * @return a {@code Collector}
      * @since 1.2.0
      */
+    @NotNull
     public static <T, K, V, M extends Map<K, V>> Collector<T, ?, M> toMap(
-            final Function<? super T, ? extends K> keyMapper,
-            final Function<? super T, ? extends V> valueMapper,
-            final BinaryOperator<V> mergeFunction,
-            final Supplier<M> mapFactory) {
+            @NotNull final Function<? super T, ? extends K> keyMapper,
+            @NotNull final Function<? super T, ? extends V> valueMapper,
+            @NotNull final BinaryOperator<V> mergeFunction,
+            @NotNull final Supplier<M> mapFactory) {
         return new CollectorsImpl<T, M, M>(
 
                 mapFactory,
 
                 new BiConsumer<M, T>() {
                     @Override
-                    public void accept(M map, T t) {
+                    public void accept(@NotNull M map, T t) {
                         final K key = keyMapper.apply(t);
                         final V value = valueMapper.apply(t);
                         mapMerge(map, key, value, mergeFunction);
@@ -334,10 +352,11 @@ public final class Collectors {
      * @return a {@code Collector}
      * @since 1.2.0
      */
+    @NotNull
     public static <T, K, V> Collector<T, ?, Map<K, V>> toUnmodifiableMap(
-            final Function<? super T, ? extends K> keyMapper,
-            final Function<? super T, ? extends V> valueMapper,
-            final BinaryOperator<V> mergeFunction) {
+            @NotNull final Function<? super T, ? extends K> keyMapper,
+            @NotNull final Function<? super T, ? extends V> valueMapper,
+            @NotNull final BinaryOperator<V> mergeFunction) {
         return Collectors.collectingAndThen(
                 Collectors.<T, K, V, Map<K, V>>toMap(
                         keyMapper, valueMapper, mergeFunction,
@@ -350,6 +369,7 @@ public final class Collectors {
      *
      * @return a {@code Collector}
      */
+    @NotNull
     public static Collector<CharSequence, ?, String> joining() {
         return joining("");
     }
@@ -360,7 +380,8 @@ public final class Collectors {
      * @param delimiter  the delimiter between each element
      * @return a {@code Collector}
      */
-    public static Collector<CharSequence, ?, String> joining(CharSequence delimiter) {
+    @NotNull
+    public static Collector<CharSequence, ?, String> joining(@NotNull CharSequence delimiter) {
         return joining(delimiter, "", "");
     }
 
@@ -372,7 +393,11 @@ public final class Collectors {
      * @param suffix  the suffix of result
      * @return a {@code Collector}
      */
-    public static Collector<CharSequence, ?, String> joining(CharSequence delimiter, CharSequence prefix, CharSequence suffix) {
+    @NotNull
+    public static Collector<CharSequence, ?, String> joining(
+            @NotNull CharSequence delimiter,
+            @NotNull CharSequence prefix,
+            @NotNull CharSequence suffix) {
         return joining(delimiter, prefix, suffix, prefix.toString() + suffix.toString());
     }
 
@@ -385,14 +410,16 @@ public final class Collectors {
      * @param emptyValue  the string which replaces empty element if exists
      * @return a {@code Collector}
      */
+    @NotNull
     public static Collector<CharSequence, ?, String> joining(
-            final CharSequence delimiter,
-            final CharSequence prefix,
-            final CharSequence suffix,
-            final String emptyValue) {
+            @NotNull final CharSequence delimiter,
+            @NotNull final CharSequence prefix,
+            @NotNull final CharSequence suffix,
+            @NotNull final String emptyValue) {
         return new CollectorsImpl<CharSequence, StringBuilder, String>(
 
                 new Supplier<StringBuilder>() {
+                    @NotNull
                     @Override
                     public StringBuilder get() {
                         return new StringBuilder();
@@ -401,7 +428,7 @@ public final class Collectors {
 
                 new BiConsumer<StringBuilder, CharSequence>() {
                     @Override
-                    public void accept(StringBuilder t, CharSequence u) {
+                    public void accept(@NotNull StringBuilder t, CharSequence u) {
                         if (t.length() > 0) {
                             t.append(delimiter);
                         } else {
@@ -412,8 +439,9 @@ public final class Collectors {
                 },
 
                 new Function<StringBuilder, String>() {
+                    @NotNull
                     @Override
-                    public String apply(StringBuilder value) {
+                    public String apply(@NotNull StringBuilder value) {
                         if (value.length() == 0) {
                             return emptyValue;
                         } else {
@@ -435,7 +463,8 @@ public final class Collectors {
      * @return a {@code Collector}
      */
     @Deprecated
-    public static <T> Collector<T, ?, Double> averaging(final Function<? super T, Double> mapper) {
+    @NotNull
+    public static <T> Collector<T, ?, Double> averaging(@NotNull final Function<? super T, Double> mapper) {
         return averagingDouble(new ToDoubleFunction<T>() {
 
             @Override
@@ -453,7 +482,8 @@ public final class Collectors {
      * @return a {@code Collector}
      * @since 1.1.3
      */
-    public static <T> Collector<T, ?, Double> averagingInt(final ToIntFunction<? super T> mapper) {
+    @NotNull
+    public static <T> Collector<T, ?, Double> averagingInt(@NotNull final ToIntFunction<? super T> mapper) {
         return averagingHelper(new BiConsumer<long[], T>() {
             @Override
             public void accept(long[] t, T u) {
@@ -471,7 +501,8 @@ public final class Collectors {
      * @return a {@code Collector}
      * @since 1.1.3
      */
-    public static <T> Collector<T, ?, Double> averagingLong(final ToLongFunction<? super T> mapper) {
+    @NotNull
+    public static <T> Collector<T, ?, Double> averagingLong(@NotNull final ToLongFunction<? super T> mapper) {
         return averagingHelper(new BiConsumer<long[], T>() {
             @Override
             public void accept(long[] t, T u) {
@@ -481,7 +512,8 @@ public final class Collectors {
         });
     }
 
-    private static <T> Collector<T, ?, Double> averagingHelper(final BiConsumer<long[], T> accumulator) {
+    @NotNull
+    private static <T> Collector<T, ?, Double> averagingHelper(@NotNull final BiConsumer<long[], T> accumulator) {
         return new CollectorsImpl<T, long[], Double>(
 
                 LONG_2ELEMENTS_ARRAY_SUPPLIER,
@@ -489,6 +521,7 @@ public final class Collectors {
                 accumulator,
 
                 new Function<long[], Double>() {
+                    @NotNull
                     @Override
                     public Double apply(long[] t) {
                         if (t[0] == 0) return 0d;
@@ -506,7 +539,8 @@ public final class Collectors {
      * @return a {@code Collector}
      * @since 1.1.3
      */
-    public static <T> Collector<T, ?, Double> averagingDouble(final ToDoubleFunction<? super T> mapper) {
+    @NotNull
+    public static <T> Collector<T, ?, Double> averagingDouble(@NotNull final ToDoubleFunction<? super T> mapper) {
         return new CollectorsImpl<T, double[], Double>(
 
                 DOUBLE_2ELEMENTS_ARRAY_SUPPLIER,
@@ -520,6 +554,7 @@ public final class Collectors {
                 },
 
                 new Function<double[], Double>() {
+                    @NotNull
                     @Override
                     public Double apply(double[] t) {
                         if (t[0] == 0) return 0d;
@@ -537,10 +572,12 @@ public final class Collectors {
      * @return a {@code Collector}
      * @since 1.1.3
      */
-    public static <T> Collector<T, ?, Integer> summingInt(final ToIntFunction<? super T> mapper) {
+    @NotNull
+    public static <T> Collector<T, ?, Integer> summingInt(@NotNull final ToIntFunction<? super T> mapper) {
         return new CollectorsImpl<T, int[], Integer>(
 
                 new Supplier<int[]>() {
+                    @NotNull
                     @Override
                     public int[] get() {
                         return new int[] { 0 };
@@ -571,7 +608,8 @@ public final class Collectors {
      * @return a {@code Collector}
      * @since 1.1.3
      */
-    public static <T> Collector<T, ?, Long> summingLong(final ToLongFunction<? super T> mapper) {
+    @NotNull
+    public static <T> Collector<T, ?, Long> summingLong(@NotNull final ToLongFunction<? super T> mapper) {
         return new CollectorsImpl<T, long[], Long>(
 
                 LONG_2ELEMENTS_ARRAY_SUPPLIER,
@@ -600,7 +638,8 @@ public final class Collectors {
      * @return a {@code Collector}
      * @since 1.1.3
      */
-    public static <T> Collector<T, ?, Double> summingDouble(final ToDoubleFunction<? super T> mapper) {
+    @NotNull
+    public static <T> Collector<T, ?, Double> summingDouble(@NotNull final ToDoubleFunction<? super T> mapper) {
         return new CollectorsImpl<T, double[], Double>(
 
                 DOUBLE_2ELEMENTS_ARRAY_SUPPLIER,
@@ -627,6 +666,7 @@ public final class Collectors {
      * @param <T> the type of the input elements
      * @return a {@code Collector}
      */
+    @NotNull
     public static <T> Collector<T, ?, Long> counting() {
         return summingLong(new ToLongFunction<T>() {
 
@@ -646,10 +686,13 @@ public final class Collectors {
      * @return a {@code Collector}
      * @see #reducing(java.lang.Object, com.annimon.stream.function.Function, com.annimon.stream.function.BinaryOperator)
      */
-    public static <T> Collector<T, ?, T> reducing(final T identity, final BinaryOperator<T> op) {
+    @NotNull
+    public static <T> Collector<T, ?, T> reducing(@Nullable  final T identity,
+                                                  @NotNull final BinaryOperator<T> op) {
         return new CollectorsImpl<T, Tuple1<T>, T>(
 
                 new Supplier<Tuple1<T>>() {
+                    @NotNull
                     @Override
                     public Tuple1<T> get() {
                         return new Tuple1<T>(identity);
@@ -658,14 +701,14 @@ public final class Collectors {
 
                 new BiConsumer<Tuple1<T>, T>() {
                     @Override
-                    public void accept(Tuple1<T> tuple, T value) {
+                    public void accept(@NotNull Tuple1<T> tuple, T value) {
                         tuple.a = op.apply(tuple.a, value);
                     }
                 },
 
                 new Function<Tuple1<T>, T>() {
                     @Override
-                    public T apply(Tuple1<T> tuple) {
+                    public T apply(@NotNull Tuple1<T> tuple) {
                         return tuple.a;
                     }
                 }
@@ -683,13 +726,15 @@ public final class Collectors {
      * @return a {@code Collector}
      * @see #reducing(java.lang.Object, com.annimon.stream.function.BinaryOperator)
      */
+    @NotNull
     public static <T, R> Collector<T, ?, R> reducing(
-            final R identity,
-            final Function<? super T, ? extends R> mapper,
-            final BinaryOperator<R> op) {
+            @Nullable  final R identity,
+            @NotNull final Function<? super T, ? extends R> mapper,
+            @NotNull final BinaryOperator<R> op) {
         return new CollectorsImpl<T, Tuple1<R>, R>(
 
                 new Supplier<Tuple1<R>>() {
+                    @NotNull
                     @Override
                     public Tuple1<R> get() {
                         return new Tuple1<R>(identity);
@@ -698,14 +743,14 @@ public final class Collectors {
 
                 new BiConsumer<Tuple1<R>, T>() {
                     @Override
-                    public void accept(Tuple1<R> tuple, T value) {
+                    public void accept(@NotNull Tuple1<R> tuple, T value) {
                         tuple.a = op.apply(tuple.a, mapper.apply(value));
                     }
                 },
 
                 new Function<Tuple1<R>, R>() {
                     @Override
-                    public R apply(Tuple1<R> tuple) {
+                    public R apply(@NotNull Tuple1<R> tuple) {
                         return tuple.a;
                     }
                 }
@@ -723,9 +768,10 @@ public final class Collectors {
      * @return a {@code Collector}
      * @since 1.1.3
      */
+    @NotNull
     public static <T, A, R> Collector<T, ?, R> filtering(
-            final Predicate<? super T> predicate,
-            final Collector<? super T, A, R> downstream) {
+            @NotNull final Predicate<? super T> predicate,
+            @NotNull final Collector<? super T, A, R> downstream) {
         final BiConsumer<A, ? super T> accumulator = downstream.accumulator();
         return new CollectorsImpl<T, A, R>(
 
@@ -754,9 +800,10 @@ public final class Collectors {
      * @param downstream  the collector of mapped elements
      * @return a {@code Collector}
      */
+    @NotNull
     public static <T, U, A, R> Collector<T, ?, R> mapping(
-            final Function<? super T, ? extends U> mapper,
-            final Collector<? super U, A, R> downstream) {
+            @NotNull final Function<? super T, ? extends U> mapper,
+            @NotNull final Collector<? super U, A, R> downstream) {
 
         final BiConsumer<A, ? super U> accumulator = downstream.accumulator();
         return new CollectorsImpl<T, A, R>(
@@ -786,9 +833,10 @@ public final class Collectors {
      * @return a {@code Collector}
      * @since 1.1.3
      */
+    @NotNull
     public static <T, U, A, R> Collector<T, ?, R> flatMapping(
-            final Function<? super T, ? extends Stream<? extends U>> mapper,
-            final Collector<? super U, A, R> downstream) {
+            @NotNull final Function<? super T, ? extends Stream<? extends U>> mapper,
+            @NotNull final Collector<? super U, A, R> downstream) {
 
         final BiConsumer<A, ? super U> accumulator = downstream.accumulator();
         return new CollectorsImpl<T, A, R>(
@@ -824,8 +872,9 @@ public final class Collectors {
      * @param finisher  the final transformation function
      * @return a {@code Collector}
      */
+    @NotNull
     public static <T, A, IR, OR> Collector<T, A, OR> collectingAndThen(
-            Collector<T, A, IR> c, Function<IR, OR> finisher) {
+            @NotNull Collector<T, A, IR> c, Function<IR, OR> finisher) {
         Function<A, IR> downstreamFinisher = c.finisher();
         if (downstreamFinisher == null) {
             downstreamFinisher = castIdentity();
@@ -844,8 +893,9 @@ public final class Collectors {
      * @see #groupingBy(com.annimon.stream.function.Function, com.annimon.stream.Collector)
      * @see #groupingBy(com.annimon.stream.function.Function, com.annimon.stream.function.Supplier, com.annimon.stream.Collector)
      */
+    @NotNull
     public static <T, K> Collector<T, ?, Map<K, List<T>>> groupingBy(
-            Function<? super T, ? extends K> classifier) {
+            @NotNull Function<? super T, ? extends K> classifier) {
         return groupingBy(classifier, Collectors.<T>toList());
     }
 
@@ -862,9 +912,10 @@ public final class Collectors {
      * @see #groupingBy(com.annimon.stream.function.Function)
      * @see #groupingBy(com.annimon.stream.function.Function, com.annimon.stream.function.Supplier, com.annimon.stream.Collector)
      */
+    @NotNull
     public static <T, K, A, D> Collector<T, ?, Map<K, D>> groupingBy(
-            Function<? super T, ? extends K> classifier,
-            Collector<? super T, A, D> downstream) {
+            @NotNull Function<? super T, ? extends K> classifier,
+            @NotNull Collector<? super T, A, D> downstream) {
         return Collectors.<T, K, D, A, Map<K, D>>groupingBy(classifier,
                 Collectors.<K, D>hashMapSupplier(), downstream);
     }
@@ -884,18 +935,20 @@ public final class Collectors {
      * @see #groupingBy(com.annimon.stream.function.Function)
      * @see #groupingBy(com.annimon.stream.function.Function, com.annimon.stream.Collector)
      */
+    @NotNull
     public static <T, K, D, A, M extends Map<K, D>> Collector<T, ?, M> groupingBy(
-            final Function<? super T, ? extends K> classifier,
-            final Supplier<M> mapFactory,
-            final Collector<? super T, A, D> downstream) {
+            @NotNull final Function<? super T, ? extends K> classifier,
+            @NotNull final Supplier<M> mapFactory,
+            @NotNull final Collector<? super T, A, D> downstream) {
 
         @SuppressWarnings("unchecked")
         final Function<A, A> downstreamFinisher = (Function<A, A>) downstream.finisher();
         Function<Map<K, A>, M> finisher = null;
         if (downstreamFinisher != null) {
             finisher = new Function<Map<K, A>, M>() {
+                @NotNull
                 @Override
-                public M apply(Map<K, A> map) {
+                public M apply(@NotNull Map<K, A> map) {
                     // Update values of a map by a finisher function
                     for (Map.Entry<K, A> entry : map.entrySet()) {
                         A value = entry.getValue();
@@ -916,7 +969,7 @@ public final class Collectors {
 
                 new BiConsumer<Map<K, A>, T>() {
                     @Override
-                    public void accept(Map<K, A> map, T t) {
+                    public void accept(@NotNull Map<K, A> map, T t) {
                         K key = Objects.requireNonNull(classifier.apply(t), "element cannot be mapped to a null key");
                         // Get container with currently grouped elements
                         A container = map.get(key);
@@ -943,8 +996,9 @@ public final class Collectors {
      * @return a {@code Collector}
      * @since 1.1.9
      */
+    @NotNull
     public static <T> Collector<T, ?, Map<Boolean, List<T>>> partitioningBy(
-            Predicate<? super T> predicate) {
+            @NotNull Predicate<? super T> predicate) {
         return partitioningBy(predicate, Collectors.<T>toList());
     }
 
@@ -960,13 +1014,15 @@ public final class Collectors {
      * @return a {@code Collector}
      * @since 1.1.9
      */
+    @NotNull
     public static <T, D, A> Collector<T, ?, Map<Boolean, D>> partitioningBy(
-            final Predicate<? super T> predicate,
-            final Collector<? super T, A, D> downstream) {
+            @NotNull final Predicate<? super T> predicate,
+            @NotNull final Collector<? super T, A, D> downstream) {
 
         final BiConsumer<A, ? super T> downstreamAccumulator = downstream.accumulator();
         return new CollectorsImpl<T, Tuple2<A>, Map<Boolean, D>>(
                 new Supplier<Tuple2<A>>() {
+                    @NotNull
                     @Override
                     public Tuple2<A> get() {
                         return new Tuple2<A>(
@@ -976,14 +1032,15 @@ public final class Collectors {
                 },
                 new BiConsumer<Tuple2<A>, T>() {
                     @Override
-                    public void accept(Tuple2<A> container, T t) {
+                    public void accept(@NotNull Tuple2<A> container, T t) {
                         downstreamAccumulator.accept(
                                 predicate.test(t) ? container.a : container.b, t);
                     }
                 },
                 new Function<Tuple2<A>, Map<Boolean, D>>() {
+                    @NotNull
                     @Override
-                    public Map<Boolean, D> apply(Tuple2<A> container) {
+                    public Map<Boolean, D> apply(@NotNull Tuple2<A> container) {
                         final Function<A, D> downstreamFinisher = downstream.finisher();
                         final Function<A, D> finisher = downstreamFinisher == null
                                 ? Collectors.<A, D>castIdentity()
@@ -997,9 +1054,11 @@ public final class Collectors {
         );
     }
 
+    @NotNull
     private static <K, V>  Supplier<Map<K, V>> hashMapSupplier() {
         return new Supplier<Map<K, V>>() {
 
+            @NotNull
             @Override
             public Map<K, V> get() {
                 return new HashMap<K, V>();
@@ -1007,13 +1066,14 @@ public final class Collectors {
         };
     }
 
+    @NotNull
     private static IllegalStateException duplicateKeyException(Object key, Object old, Object value) {
         return new IllegalStateException(String.format(
                 "Duplicate key %s (attempted merging values %s and %s)",
                 key, old, value));
     }
 
-    private static <K, V> void mapMerge(Map<K, V> map, K key, V value, BinaryOperator<V> merger) {
+    private static <K, V> void mapMerge(@NotNull Map<K, V> map, K key, V value, @NotNull BinaryOperator<V> merger) {
         final V oldValue = map.get(key);
         final V newValue;
         if (oldValue == null) {
@@ -1029,10 +1089,12 @@ public final class Collectors {
         }
     }
 
+    @NotNull
     private static <K, V> UnaryOperator<Map<K, V>> toUnmodifiableMapConverter() {
         return new UnaryOperator<Map<K, V>>() {
+            @NotNull
             @Override
-            public Map<K, V> apply(Map<K, V> map) {
+            public Map<K, V> apply(@NotNull Map<K, V> map) {
                 Objects.requireNonNullElements(map.keySet());
                 Objects.requireNonNullElements(map.values());
                 return Collections.unmodifiableMap(map);
@@ -1040,12 +1102,14 @@ public final class Collectors {
         };
     }
 
+    @NotNull
     @SuppressWarnings("unchecked")
     static <A, R> Function<A, R> castIdentity() {
         return new Function<A, R>() {
 
+            @NotNull
             @Override
-            public R apply(A value) {
+            public R apply(@NotNull A value) {
                 return (R) value;
             }
         };
@@ -1095,6 +1159,7 @@ public final class Collectors {
             return accumulator;
         }
 
+        @Nullable
         @Override
         public Function<A, R> finisher() {
             return finisher;

--- a/stream/src/main/java/com/annimon/stream/ComparatorCompat.java
+++ b/stream/src/main/java/com/annimon/stream/ComparatorCompat.java
@@ -6,6 +6,8 @@ import com.annimon.stream.function.ToIntFunction;
 import com.annimon.stream.function.ToLongFunction;
 import java.util.Collections;
 import java.util.Comparator;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Backported default and static methods from Java 8 {@link java.util.Comparator} interface.
@@ -18,7 +20,7 @@ public final class ComparatorCompat<T> implements Comparator<T> {
             NATURAL_ORDER = new ComparatorCompat<Comparable<Object>>(
                     new Comparator<Comparable<Object>>() {
                         @Override
-                        public int compare(Comparable<Object> o1, Comparable<Object> o2) {
+                        public int compare(@NotNull Comparable<Object> o1, @NotNull Comparable<Object> o2) {
                             return o1.compareTo(o2);
                         }
                     });
@@ -33,6 +35,7 @@ public final class ComparatorCompat<T> implements Comparator<T> {
      * @param <T> the type of the objects compared by the comparator
      * @return a comparator
      */
+    @NotNull
     @SuppressWarnings("unchecked")
     public static <T extends Comparable<? super T>> ComparatorCompat<T> naturalOrder() {
         return (ComparatorCompat<T>) NATURAL_ORDER;
@@ -45,6 +48,7 @@ public final class ComparatorCompat<T> implements Comparator<T> {
      * @return a comparator
      * @see Collections#reverseOrder()
      */
+    @NotNull
     @SuppressWarnings("unchecked")
     public static <T extends Comparable<? super T>> ComparatorCompat<T> reverseOrder() {
         return (ComparatorCompat<T>) REVERSE_ORDER;
@@ -61,6 +65,7 @@ public final class ComparatorCompat<T> implements Comparator<T> {
      * @see Collections#reverseOrder(java.util.Comparator)
      * @throws NullPointerException if {@code comparator} is null
      */
+    @NotNull
     public static <T> Comparator<T> reversed(Comparator<T> comparator) {
         return Collections.reverseOrder(comparator);
     }
@@ -75,9 +80,10 @@ public final class ComparatorCompat<T> implements Comparator<T> {
      * @return a comparator
      * @throws NullPointerException if {@code c1} or {@code c2} is null
      */
+    @NotNull
     public static <T> Comparator<T> thenComparing(
-            final Comparator<? super T> c1,
-            final Comparator<? super T> c2) {
+            @NotNull final Comparator<? super T> c1,
+            @NotNull final Comparator<? super T> c2) {
         Objects.requireNonNull(c1);
         Objects.requireNonNull(c2);
         return new Comparator<T>() {
@@ -101,9 +107,10 @@ public final class ComparatorCompat<T> implements Comparator<T> {
      * @return a comparator
      * @throws NullPointerException if {@code keyExtractor} or {@code keyComparator} is null
      */
+    @NotNull
     public static <T, U> ComparatorCompat<T> comparing(
-            final Function<? super T, ? extends U> keyExtractor,
-            final Comparator<? super U> keyComparator) {
+            @NotNull final Function<? super T, ? extends U> keyExtractor,
+            @NotNull final Comparator<? super U> keyComparator) {
         Objects.requireNonNull(keyExtractor);
         Objects.requireNonNull(keyComparator);
         return new ComparatorCompat<T>(new Comparator<T>() {
@@ -127,8 +134,9 @@ public final class ComparatorCompat<T> implements Comparator<T> {
      * @return a comparator
      * @throws NullPointerException if {@code keyExtractor} is null
      */
+    @NotNull
     public static <T, U extends Comparable<? super U>> ComparatorCompat<T> comparing(
-            final Function<? super T, ? extends U> keyExtractor) {
+            @NotNull final Function<? super T, ? extends U> keyExtractor) {
         Objects.requireNonNull(keyExtractor);
         return new ComparatorCompat<T>(new Comparator<T>() {
 
@@ -150,8 +158,9 @@ public final class ComparatorCompat<T> implements Comparator<T> {
      * @return a comparator
      * @throws NullPointerException if {@code keyExtractor} is null
      */
+    @NotNull
     public static <T> ComparatorCompat<T> comparingInt(
-            final ToIntFunction<? super T> keyExtractor) {
+            @NotNull final ToIntFunction<? super T> keyExtractor) {
         Objects.requireNonNull(keyExtractor);
         return new ComparatorCompat<T>(new Comparator<T>() {
 
@@ -173,8 +182,9 @@ public final class ComparatorCompat<T> implements Comparator<T> {
      * @return a comparator
      * @throws NullPointerException if {@code keyExtractor} is null
      */
+    @NotNull
     public static <T> ComparatorCompat<T> comparingLong(
-            final ToLongFunction<? super T> keyExtractor) {
+            @NotNull final ToLongFunction<? super T> keyExtractor) {
         Objects.requireNonNull(keyExtractor);
         return new ComparatorCompat<T>(new Comparator<T>() {
 
@@ -196,8 +206,9 @@ public final class ComparatorCompat<T> implements Comparator<T> {
      * @return a comparator
      * @throws NullPointerException if {@code keyExtractor} is null
      */
+    @NotNull
     public static <T> ComparatorCompat<T> comparingDouble(
-            final ToDoubleFunction<? super T> keyExtractor) {
+            @NotNull final ToDoubleFunction<? super T> keyExtractor) {
         Objects.requireNonNull(keyExtractor);
         return new ComparatorCompat<T>(new Comparator<T>() {
 
@@ -217,6 +228,7 @@ public final class ComparatorCompat<T> implements Comparator<T> {
      * @param <T> the type of the objects compared by the comparator
      * @return a comparator
      */
+    @NotNull
     public static <T> ComparatorCompat<T> nullsFirst() {
         return nullsComparator(true, null);
     }
@@ -230,6 +242,7 @@ public final class ComparatorCompat<T> implements Comparator<T> {
      * @param comparator  a comparator for comparing non-null values
      * @return a comparator
      */
+    @NotNull
     public static <T> ComparatorCompat<T> nullsFirst(Comparator<? super T> comparator) {
         return nullsComparator(true, comparator);
     }
@@ -241,6 +254,7 @@ public final class ComparatorCompat<T> implements Comparator<T> {
      * @param <T> the type of the objects compared by the comparator
      * @return a comparator
      */
+    @NotNull
     public static <T> ComparatorCompat<T> nullsLast() {
         return nullsComparator(false, null);
     }
@@ -254,16 +268,18 @@ public final class ComparatorCompat<T> implements Comparator<T> {
      * @param comparator  a comparator for comparing non-null values
      * @return a comparator
      */
+    @NotNull
     public static <T> ComparatorCompat<T> nullsLast(Comparator<? super T> comparator) {
         return nullsComparator(false, comparator);
     }
 
     private static <T> ComparatorCompat<T> nullsComparator(
-            final boolean nullFirst, final Comparator<? super T> comparator) {
+            final boolean nullFirst,
+            @Nullable final Comparator<? super T> comparator) {
         return new ComparatorCompat<T>(new Comparator<T>() {
 
             @Override
-            public int compare(T t1, T t2) {
+            public int compare(@Nullable T t1, @Nullable T t2) {
                 if (t1 == null) {
                     return (t2 == null) ? 0 : (nullFirst ? -1 : 1);
                 } else if (t2 == null) {
@@ -282,14 +298,16 @@ public final class ComparatorCompat<T> implements Comparator<T> {
      * @param comparator  the comparator to be chained
      * @return a {@code ComparatorCompat} instance
      */
-    public static <T> ComparatorCompat<T> chain(Comparator<T> comparator) {
+    @NotNull
+    public static <T> ComparatorCompat<T> chain(@NotNull Comparator<T> comparator) {
         return new ComparatorCompat<T>(comparator);
     }
 
 
+    @NotNull
     private final Comparator<? super T> comparator;
 
-    public ComparatorCompat(Comparator<? super T> comparator) {
+    public ComparatorCompat(@NotNull Comparator<? super T> comparator) {
         this.comparator = comparator;
     }
 
@@ -299,6 +317,7 @@ public final class ComparatorCompat<T> implements Comparator<T> {
      * @return the new {@code ComparatorCompat} instance
      * @see ComparatorCompat#reverseOrder()
      */
+    @NotNull
     public ComparatorCompat<T> reversed() {
         return new ComparatorCompat<T>(Collections.reverseOrder(comparator));
     }
@@ -310,7 +329,8 @@ public final class ComparatorCompat<T> implements Comparator<T> {
      *               comparator compares two objects that are equal
      * @return the new {@code ComparatorCompat} instance
      */
-    public ComparatorCompat<T> thenComparing(final Comparator<? super T> other) {
+    @NotNull
+    public ComparatorCompat<T> thenComparing(@NotNull final Comparator<? super T> other) {
         Objects.requireNonNull(other);
         return new ComparatorCompat<T>(new Comparator<T>() {
 
@@ -331,9 +351,10 @@ public final class ComparatorCompat<T> implements Comparator<T> {
      * @param keyComparator  the comparator used to compare the sort key
      * @return the new {@code ComparatorCompat} instance
      */
+    @NotNull
     public <U> ComparatorCompat<T> thenComparing(
-            Function<? super T, ? extends U> keyExtractor,
-            Comparator<? super U> keyComparator) {
+            @NotNull Function<? super T, ? extends U> keyExtractor,
+            @NotNull Comparator<? super U> keyComparator) {
         return thenComparing(comparing(keyExtractor, keyComparator));
     }
 
@@ -345,8 +366,9 @@ public final class ComparatorCompat<T> implements Comparator<T> {
      * @param keyExtractor  the function that extracts the sort key
      * @return the new {@code ComparatorCompat} instance
      */
+    @NotNull
     public <U extends Comparable<? super U>> ComparatorCompat<T> thenComparing(
-            Function<? super T, ? extends U> keyExtractor) {
+            @NotNull Function<? super T, ? extends U> keyExtractor) {
         return thenComparing(comparing(keyExtractor));
     }
 
@@ -357,7 +379,8 @@ public final class ComparatorCompat<T> implements Comparator<T> {
      * @param keyExtractor  the function that extracts the sort key
      * @return the new {@code ComparatorCompat} instance
      */
-    public ComparatorCompat<T> thenComparingInt(ToIntFunction<? super T> keyExtractor) {
+    @NotNull
+    public ComparatorCompat<T> thenComparingInt(@NotNull ToIntFunction<? super T> keyExtractor) {
         return thenComparing(comparingInt(keyExtractor));
     }
 
@@ -368,7 +391,8 @@ public final class ComparatorCompat<T> implements Comparator<T> {
      * @param keyExtractor  the function that extracts the sort key
      * @return the new {@code ComparatorCompat} instance
      */
-    public ComparatorCompat<T> thenComparingLong(ToLongFunction<? super T> keyExtractor) {
+    @NotNull
+    public ComparatorCompat<T> thenComparingLong(@NotNull ToLongFunction<? super T> keyExtractor) {
         return thenComparing(comparingLong(keyExtractor));
     }
 
@@ -379,7 +403,8 @@ public final class ComparatorCompat<T> implements Comparator<T> {
      * @param keyExtractor  the function that extracts the sort key
      * @return the new {@code ComparatorCompat} instance
      */
-    public ComparatorCompat<T> thenComparingDouble(ToDoubleFunction<? super T> keyExtractor) {
+    @NotNull
+    public ComparatorCompat<T> thenComparingDouble(@NotNull ToDoubleFunction<? super T> keyExtractor) {
         return thenComparing(comparingDouble(keyExtractor));
     }
 
@@ -389,6 +414,7 @@ public final class ComparatorCompat<T> implements Comparator<T> {
      * @deprecated  As of release 1.1.7, it is unnecessary to call this method.
      * @return a comparator
      */
+    @NotNull
     @SuppressWarnings("unchecked")
     public Comparator<T> comparator() {
         return (Comparator<T>) comparator;

--- a/stream/src/main/java/com/annimon/stream/ComparatorCompat.java
+++ b/stream/src/main/java/com/annimon/stream/ComparatorCompat.java
@@ -66,7 +66,7 @@ public final class ComparatorCompat<T> implements Comparator<T> {
      * @throws NullPointerException if {@code comparator} is null
      */
     @NotNull
-    public static <T> Comparator<T> reversed(Comparator<T> comparator) {
+    public static <T> Comparator<T> reversed(@Nullable Comparator<T> comparator) {
         return Collections.reverseOrder(comparator);
     }
 
@@ -243,7 +243,7 @@ public final class ComparatorCompat<T> implements Comparator<T> {
      * @return a comparator
      */
     @NotNull
-    public static <T> ComparatorCompat<T> nullsFirst(Comparator<? super T> comparator) {
+    public static <T> ComparatorCompat<T> nullsFirst(@Nullable Comparator<? super T> comparator) {
         return nullsComparator(true, comparator);
     }
 
@@ -269,7 +269,7 @@ public final class ComparatorCompat<T> implements Comparator<T> {
      * @return a comparator
      */
     @NotNull
-    public static <T> ComparatorCompat<T> nullsLast(Comparator<? super T> comparator) {
+    public static <T> ComparatorCompat<T> nullsLast(@Nullable Comparator<? super T> comparator) {
         return nullsComparator(false, comparator);
     }
 

--- a/stream/src/main/java/com/annimon/stream/DoubleStream.java
+++ b/stream/src/main/java/com/annimon/stream/DoubleStream.java
@@ -10,6 +10,8 @@ import com.annimon.stream.operator.*;
 import java.io.Closeable;
 import java.util.Comparator;
 import java.util.NoSuchElementException;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * A sequence of {@code double}-valued elements supporting aggregate operations.
@@ -41,6 +43,7 @@ public final class DoubleStream implements Closeable {
      *
      * @return the empty stream
      */
+    @NotNull
     public static DoubleStream empty() {
         return EMPTY;
     }
@@ -52,7 +55,8 @@ public final class DoubleStream implements Closeable {
      * @return the new {@code DoubleStream}
      * @throws NullPointerException if {@code iterator} is null
      */
-    public static DoubleStream of(PrimitiveIterator.OfDouble iterator) {
+    @NotNull
+    public static DoubleStream of(@NotNull PrimitiveIterator.OfDouble iterator) {
         Objects.requireNonNull(iterator);
         return new DoubleStream(iterator);
     }
@@ -64,7 +68,8 @@ public final class DoubleStream implements Closeable {
      * @return the new stream
      * @throws NullPointerException if {@code values} is null
      */
-    public static DoubleStream of(final double... values) {
+    @NotNull
+    public static DoubleStream of(@NotNull final double... values) {
         Objects.requireNonNull(values);
         if (values.length == 0) {
             return DoubleStream.empty();
@@ -78,6 +83,7 @@ public final class DoubleStream implements Closeable {
      * @param t  element of the stream
      * @return the new stream
      */
+    @NotNull
     public static DoubleStream of(final double t) {
         return new DoubleStream(new DoubleArray(new double[] { t }));
     }
@@ -89,7 +95,8 @@ public final class DoubleStream implements Closeable {
      * @return a new infinite sequential {@code DoubleStream}
      * @throws NullPointerException if {@code s} is null
      */
-    public static DoubleStream generate(final DoubleSupplier s) {
+    @NotNull
+    public static DoubleStream generate(@NotNull final DoubleSupplier s) {
         Objects.requireNonNull(s);
         return new DoubleStream(new DoubleGenerate(s));
     }
@@ -116,7 +123,9 @@ public final class DoubleStream implements Closeable {
      * @return a new sequential {@code DoubleStream}
      * @throws NullPointerException if {@code f} is null
      */
-    public static DoubleStream iterate(final double seed, final DoubleUnaryOperator f) {
+    @NotNull
+    public static DoubleStream iterate(final double seed,
+                                       @NotNull final DoubleUnaryOperator f) {
         Objects.requireNonNull(f);
         return new DoubleStream(new DoubleIterate(seed, f));
     }
@@ -140,8 +149,11 @@ public final class DoubleStream implements Closeable {
      * @throws NullPointerException if {@code op} is null
      * @since 1.1.5
      */
-    public static DoubleStream iterate(final double seed,
-            final DoublePredicate predicate, final DoubleUnaryOperator op) {
+    @NotNull
+    public static DoubleStream iterate(
+            final double seed,
+            @NotNull final DoublePredicate predicate,
+            @NotNull final DoubleUnaryOperator op) {
         Objects.requireNonNull(predicate);
         return iterate(seed, op).takeWhile(predicate);
     }
@@ -161,7 +173,10 @@ public final class DoubleStream implements Closeable {
      * @return the new concatenated stream
      * @throws NullPointerException if {@code a} or {@code b} is null
      */
-    public static DoubleStream concat(final DoubleStream a, final DoubleStream b) {
+    @NotNull
+    public static DoubleStream concat(
+            @NotNull final DoubleStream a,
+            @NotNull final DoubleStream b) {
         Objects.requireNonNull(a);
         Objects.requireNonNull(b);
         DoubleStream result = new DoubleStream(new DoubleConcat(a.iterator, b.iterator));
@@ -266,7 +281,8 @@ public final class DoubleStream implements Closeable {
      * @see Stream#custom(com.annimon.stream.function.Function)
      * @throws NullPointerException if {@code function} is null
      */
-    public <R> R custom(final Function<DoubleStream, R> function) {
+    @Nullable
+    public <R> R custom(@NotNull final Function<DoubleStream, R> function) {
         Objects.requireNonNull(function);
         return function.apply(this);
     }
@@ -280,6 +296,7 @@ public final class DoubleStream implements Closeable {
      * @return a {@code Stream} consistent of the elements of this stream,
      *         each boxed to an {@code Double}
      */
+    @NotNull
     public Stream<Double> boxed() {
         return new Stream<Double>(params, iterator);
     }
@@ -299,7 +316,8 @@ public final class DoubleStream implements Closeable {
      * @param predicate  the predicate used to filter elements
      * @return the new stream
      */
-    public DoubleStream filter(final DoublePredicate predicate) {
+    @NotNull
+    public DoubleStream filter(@NotNull final DoublePredicate predicate) {
         return new DoubleStream(params, new DoubleFilter(iterator, predicate));
     }
 
@@ -322,7 +340,8 @@ public final class DoubleStream implements Closeable {
      * @return the new stream
      * @since 1.2.1
      */
-    public DoubleStream filterIndexed(IndexedDoublePredicate predicate) {
+    @NotNull
+    public DoubleStream filterIndexed(@NotNull IndexedDoublePredicate predicate) {
         return filterIndexed(0, 1, predicate);
     }
 
@@ -349,7 +368,9 @@ public final class DoubleStream implements Closeable {
      * @return the new stream
      * @since 1.2.1
      */
-    public DoubleStream filterIndexed(int from, int step, IndexedDoublePredicate predicate) {
+    @NotNull
+    public DoubleStream filterIndexed(int from, int step,
+                                      @NotNull IndexedDoublePredicate predicate) {
         return new DoubleStream(params, new DoubleFilterIndexed(
                 new PrimitiveIndexedIterator.OfDouble(from, step, iterator),
                 predicate));
@@ -363,7 +384,8 @@ public final class DoubleStream implements Closeable {
      * @param predicate  the predicate used to filter elements
      * @return the new stream
      */
-    public DoubleStream filterNot(final DoublePredicate predicate) {
+    @NotNull
+    public DoubleStream filterNot(@NotNull final DoublePredicate predicate) {
         return filter(DoublePredicate.Util.negate(predicate));
     }
 
@@ -384,7 +406,8 @@ public final class DoubleStream implements Closeable {
      * @return the new stream
      * @see Stream#map(com.annimon.stream.function.Function)
      */
-    public DoubleStream map(final DoubleUnaryOperator mapper) {
+    @NotNull
+    public DoubleStream map(@NotNull final DoubleUnaryOperator mapper) {
         return new DoubleStream(params, new DoubleMap(iterator, mapper));
     }
 
@@ -406,7 +429,8 @@ public final class DoubleStream implements Closeable {
      * @return the new stream
      * @since 1.2.1
      */
-    public DoubleStream mapIndexed(IndexedDoubleUnaryOperator mapper) {
+    @NotNull
+    public DoubleStream mapIndexed(@NotNull IndexedDoubleUnaryOperator mapper) {
         return mapIndexed(0, 1, mapper);
     }
 
@@ -432,7 +456,9 @@ public final class DoubleStream implements Closeable {
      * @return the new stream
      * @since 1.2.1
      */
-    public DoubleStream mapIndexed(int from, int step, IndexedDoubleUnaryOperator mapper) {
+    @NotNull
+    public DoubleStream mapIndexed(int from, int step,
+                                   @NotNull IndexedDoubleUnaryOperator mapper) {
         return new DoubleStream(params, new DoubleMapIndexed(
                 new PrimitiveIndexedIterator.OfDouble(from, step, iterator),
                 mapper));
@@ -448,7 +474,8 @@ public final class DoubleStream implements Closeable {
      * @param mapper  the mapper function used to apply to each element
      * @return the new {@code Stream}
      */
-    public <R> Stream<R> mapToObj(final DoubleFunction<? extends R> mapper) {
+    @NotNull
+    public <R> Stream<R> mapToObj(@NotNull final DoubleFunction<? extends R> mapper) {
         return new Stream<R>(params, new DoubleMapToObj<R>(iterator, mapper));
     }
 
@@ -461,7 +488,8 @@ public final class DoubleStream implements Closeable {
      * @param mapper  the mapper function used to apply to each element
      * @return the new {@code IntStream}
      */
-    public IntStream mapToInt(final DoubleToIntFunction mapper) {
+    @NotNull
+    public IntStream mapToInt(@NotNull final DoubleToIntFunction mapper) {
         return new IntStream(params, new DoubleMapToInt(iterator, mapper));
     }
 
@@ -474,7 +502,8 @@ public final class DoubleStream implements Closeable {
      * @param mapper  the mapper function used to apply to each element
      * @return the new {@code LongStream}
      */
-    public LongStream mapToLong(final DoubleToLongFunction mapper) {
+    @NotNull
+    public LongStream mapToLong(@NotNull final DoubleToLongFunction mapper) {
         return new LongStream(params, new DoubleMapToLong(iterator, mapper));
     }
 
@@ -496,7 +525,8 @@ public final class DoubleStream implements Closeable {
      * @return the new stream
      * @see Stream#flatMap(com.annimon.stream.function.Function)
      */
-    public DoubleStream flatMap(final DoubleFunction<? extends DoubleStream> mapper) {
+    @NotNull
+    public DoubleStream flatMap(@NotNull final DoubleFunction<? extends DoubleStream> mapper) {
         return new DoubleStream(params, new DoubleFlatMap(iterator, mapper));
     }
 
@@ -513,6 +543,7 @@ public final class DoubleStream implements Closeable {
      *
      * @return the new stream
      */
+    @NotNull
     public DoubleStream distinct() {
         return boxed().distinct().mapToDouble(UNBOX_FUNCTION);
     }
@@ -530,6 +561,7 @@ public final class DoubleStream implements Closeable {
      *
      * @return the new stream
      */
+    @NotNull
     public DoubleStream sorted() {
         return new DoubleStream(params, new DoubleSorted(iterator));
     }
@@ -550,7 +582,8 @@ public final class DoubleStream implements Closeable {
      * @param comparator  the {@code Comparator} to compare elements
      * @return the new {@code DoubleStream}
      */
-    public DoubleStream sorted(Comparator<Double> comparator) {
+    @NotNull
+    public DoubleStream sorted(@NotNull Comparator<Double> comparator) {
         return boxed().sorted(comparator).mapToDouble(UNBOX_FUNCTION);
     }
 
@@ -571,6 +604,7 @@ public final class DoubleStream implements Closeable {
      * @throws IllegalArgumentException if {@code stepWidth} is zero or negative
      * @see Stream#sample(int)
      */
+    @NotNull
     public DoubleStream sample(final int stepWidth) {
         if (stepWidth <= 0) throw new IllegalArgumentException("stepWidth cannot be zero or negative");
         if (stepWidth == 1) return this;
@@ -585,7 +619,8 @@ public final class DoubleStream implements Closeable {
      * @param action the action to be performed on each element
      * @return the new stream
      */
-    public DoubleStream peek(final DoubleConsumer action) {
+    @NotNull
+    public DoubleStream peek(@NotNull final DoubleConsumer action) {
         return new DoubleStream(params, new DoublePeek(iterator, action));
     }
 
@@ -609,7 +644,8 @@ public final class DoubleStream implements Closeable {
      * @throws NullPointerException if {@code accumulator} is null
      * @since 1.1.6
      */
-    public DoubleStream scan(final DoubleBinaryOperator accumulator) {
+    @NotNull
+    public DoubleStream scan(@NotNull final DoubleBinaryOperator accumulator) {
         Objects.requireNonNull(accumulator);
         return new DoubleStream(params, new DoubleScan(iterator, accumulator));
     }
@@ -636,7 +672,9 @@ public final class DoubleStream implements Closeable {
      * @throws NullPointerException if {@code accumulator} is null
      * @since 1.1.6
      */
-    public DoubleStream scan(final double identity, final DoubleBinaryOperator accumulator) {
+    @NotNull
+    public DoubleStream scan(final double identity,
+                             @NotNull final DoubleBinaryOperator accumulator) {
         Objects.requireNonNull(accumulator);
         return new DoubleStream(params, new DoubleScanIdentity(iterator, identity, accumulator));
     }
@@ -656,7 +694,8 @@ public final class DoubleStream implements Closeable {
      * @param predicate  the predicate used to take elements
      * @return the new {@code DoubleStream}
      */
-    public DoubleStream takeWhile(final DoublePredicate predicate) {
+    @NotNull
+    public DoubleStream takeWhile(@NotNull final DoublePredicate predicate) {
         return new DoubleStream(params, new DoubleTakeWhile(iterator, predicate));
     }
 
@@ -678,7 +717,8 @@ public final class DoubleStream implements Closeable {
      * @return the new {@code DoubleStream}
      * @since 1.1.6
      */
-    public DoubleStream takeUntil(final DoublePredicate stopPredicate) {
+    @NotNull
+    public DoubleStream takeUntil(@NotNull final DoublePredicate stopPredicate) {
         return new DoubleStream(params, new DoubleTakeUntil(iterator, stopPredicate));
     }
 
@@ -697,7 +737,8 @@ public final class DoubleStream implements Closeable {
      * @param predicate  the predicate used to drop elements
      * @return the new {@code DoubleStream}
      */
-    public DoubleStream dropWhile(final DoublePredicate predicate) {
+    @NotNull
+    public DoubleStream dropWhile(@NotNull final DoublePredicate predicate) {
         return new DoubleStream(params, new DoubleDropWhile(iterator, predicate));
     }
 
@@ -722,6 +763,7 @@ public final class DoubleStream implements Closeable {
      * @return the new stream
      * @throws IllegalArgumentException if {@code maxSize} is negative
      */
+    @NotNull
     public DoubleStream limit(final long maxSize) {
         if (maxSize < 0) throw new IllegalArgumentException("maxSize cannot be negative");
         if (maxSize == 0) return DoubleStream.empty();
@@ -750,6 +792,7 @@ public final class DoubleStream implements Closeable {
      * @return the new stream
      * @throws IllegalArgumentException if {@code n} is negative
      */
+    @NotNull
     public DoubleStream skip(final long n) {
         if (n < 0) throw new IllegalArgumentException("n cannot be negative");
         if (n == 0) return this;
@@ -763,7 +806,7 @@ public final class DoubleStream implements Closeable {
      *
      * @param action  the action to be performed on each element
      */
-    public void forEach(DoubleConsumer action) {
+    public void forEach(@NotNull DoubleConsumer action) {
         while (iterator.hasNext()) {
             action.accept(iterator.nextDouble());
         }
@@ -777,7 +820,7 @@ public final class DoubleStream implements Closeable {
      * @param action  the action to be performed on each element
      * @since 1.2.1
      */
-    public void forEachIndexed(IndexedDoubleConsumer action) {
+    public void forEachIndexed(@NotNull IndexedDoubleConsumer action) {
         forEachIndexed(0, 1, action);
     }
 
@@ -791,7 +834,8 @@ public final class DoubleStream implements Closeable {
      * @param action  the action to be performed on each element
      * @since 1.2.1
      */
-    public void forEachIndexed(int from, int step, IndexedDoubleConsumer action) {
+    public void forEachIndexed(int from, int step,
+                               @NotNull IndexedDoubleConsumer action) {
         int index = from;
         while (iterator.hasNext()) {
             action.accept(index, iterator.nextDouble());
@@ -826,7 +870,7 @@ public final class DoubleStream implements Closeable {
      * @see #min()
      * @see #max()
      */
-    public double reduce(double identity, DoubleBinaryOperator accumulator) {
+    public double reduce(double identity, @NotNull DoubleBinaryOperator accumulator) {
         double result = identity;
         while (iterator.hasNext()) {
             final double value = iterator.nextDouble();
@@ -848,7 +892,8 @@ public final class DoubleStream implements Closeable {
      * @return the result of the reduction
      * @see #reduce(com.annimon.stream.function.DoubleBinaryOperator)
      */
-    public OptionalDouble reduce(DoubleBinaryOperator accumulator) {
+    @NotNull
+    public OptionalDouble reduce(@NotNull DoubleBinaryOperator accumulator) {
         boolean foundAny = false;
         double result = 0;
         while (iterator.hasNext()) {
@@ -870,6 +915,7 @@ public final class DoubleStream implements Closeable {
      *
      * @return an array containing the elements of this stream
      */
+    @NotNull
     public double[] toArray() {
         return Operators.toDoubleArray(iterator);
     }
@@ -885,7 +931,9 @@ public final class DoubleStream implements Closeable {
      * @return the result of collect elements
      * @see Stream#collect(com.annimon.stream.function.Supplier, com.annimon.stream.function.BiConsumer)
      */
-    public <R> R collect(Supplier<R> supplier, ObjDoubleConsumer<R> accumulator) {
+    @Nullable
+    public <R> R collect(@NotNull Supplier<R> supplier,
+                         @NotNull ObjDoubleConsumer<R> accumulator) {
         final R result = supplier.get();
         while (iterator.hasNext()) {
             final double value = iterator.nextDouble();
@@ -915,6 +963,7 @@ public final class DoubleStream implements Closeable {
      *
      * @return the minimum element
      */
+    @NotNull
     public OptionalDouble min() {
         return reduce(new DoubleBinaryOperator() {
             @Override
@@ -932,6 +981,7 @@ public final class DoubleStream implements Closeable {
      *
      * @return the maximum element
      */
+    @NotNull
     public OptionalDouble max() {
         return reduce(new DoubleBinaryOperator() {
             @Override
@@ -964,6 +1014,7 @@ public final class DoubleStream implements Closeable {
      *
      * @return the average of elements in this stream
      */
+    @NotNull
     public OptionalDouble average() {
         long count = 0;
         double sum = 0d;
@@ -998,7 +1049,7 @@ public final class DoubleStream implements Closeable {
      * @return {@code true} if any elements of the stream match the provided
      *         predicate, otherwise {@code false}
      */
-    public boolean anyMatch(DoublePredicate predicate) {
+    public boolean anyMatch(@NotNull DoublePredicate predicate) {
         while (iterator.hasNext()) {
             if (predicate.test(iterator.nextDouble()))
                 return true;
@@ -1029,7 +1080,7 @@ public final class DoubleStream implements Closeable {
      * @return {@code true} if either all elements of the stream match the
      *         provided predicate or the stream is empty, otherwise {@code false}
      */
-    public boolean allMatch(DoublePredicate predicate) {
+    public boolean allMatch(@NotNull DoublePredicate predicate) {
         while (iterator.hasNext()) {
             if (!predicate.test(iterator.nextDouble()))
                 return false;
@@ -1060,7 +1111,7 @@ public final class DoubleStream implements Closeable {
      * @return {@code true} if either no elements of the stream match the
      *         provided predicate or the stream is empty, otherwise {@code false}
      */
-    public boolean noneMatch(DoublePredicate predicate) {
+    public boolean noneMatch(@NotNull DoublePredicate predicate) {
         while (iterator.hasNext()) {
             if (predicate.test(iterator.nextDouble()))
                 return false;
@@ -1077,6 +1128,7 @@ public final class DoubleStream implements Closeable {
      * @return an {@code OptionalDouble} with first element
      *         or {@code OptionalDouble.empty()} if stream is empty
      */
+    @NotNull
     public OptionalDouble findFirst() {
         if (iterator.hasNext()) {
             return OptionalDouble.of(iterator.nextDouble());
@@ -1094,6 +1146,7 @@ public final class DoubleStream implements Closeable {
      *         or {@code OptionalDouble.empty()} if the stream is empty
      * @since 1.1.8
      */
+    @NotNull
     public OptionalDouble findLast() {
         return reduce(new DoubleBinaryOperator() {
             @Override
@@ -1161,6 +1214,7 @@ public final class DoubleStream implements Closeable {
      *         or {@code OptionalDouble.empty()} if stream is empty
      * @throws IllegalStateException if stream contains more than one element
      */
+    @NotNull
     public OptionalDouble findSingle() {
         if (!iterator.hasNext()) {
             return OptionalDouble.empty();
@@ -1182,7 +1236,8 @@ public final class DoubleStream implements Closeable {
      * @return the new stream with the close handler
      * @since 1.1.8
      */
-    public DoubleStream onClose(final Runnable closeHandler) {
+    @NotNull
+    public DoubleStream onClose(@NotNull final Runnable closeHandler) {
         Objects.requireNonNull(closeHandler);
         final Params newParams;
         if (params == null) {

--- a/stream/src/main/java/com/annimon/stream/DoubleStream.java
+++ b/stream/src/main/java/com/annimon/stream/DoubleStream.java
@@ -583,7 +583,7 @@ public final class DoubleStream implements Closeable {
      * @return the new {@code DoubleStream}
      */
     @NotNull
-    public DoubleStream sorted(@NotNull Comparator<Double> comparator) {
+    public DoubleStream sorted(@Nullable Comparator<Double> comparator) {
         return boxed().sorted(comparator).mapToDouble(UNBOX_FUNCTION);
     }
 

--- a/stream/src/main/java/com/annimon/stream/Exceptional.java
+++ b/stream/src/main/java/com/annimon/stream/Exceptional.java
@@ -40,6 +40,7 @@ public class Exceptional<T> {
      * @param <T> the type of value
      * @param supplier  a supplier function
      * @return an {@code Exceptional}
+     * @throws NullPointerException if {@code supplier} is null
      */
     @NotNull
     public static <T> Exceptional<T> of(@NotNull ThrowableSupplier<T, Throwable> supplier) {

--- a/stream/src/main/java/com/annimon/stream/Exceptional.java
+++ b/stream/src/main/java/com/annimon/stream/Exceptional.java
@@ -43,6 +43,7 @@ public class Exceptional<T> {
      */
     @NotNull
     public static <T> Exceptional<T> of(@NotNull ThrowableSupplier<T, Throwable> supplier) {
+        Objects.requireNonNull(supplier);
         try {
             return new Exceptional<T>(supplier.get(), null);
         } catch (Throwable throwable) {
@@ -60,6 +61,7 @@ public class Exceptional<T> {
     @NotNull
     @Contract("_ -> new")
     public static <T> Exceptional<T> of(@NotNull Throwable throwable) {
+        Objects.requireNonNull(throwable);
         return new Exceptional<T>(null, throwable);
     }
 

--- a/stream/src/main/java/com/annimon/stream/Exceptional.java
+++ b/stream/src/main/java/com/annimon/stream/Exceptional.java
@@ -5,6 +5,9 @@ import com.annimon.stream.function.Function;
 import com.annimon.stream.function.Supplier;
 import com.annimon.stream.function.ThrowableFunction;
 import com.annimon.stream.function.ThrowableSupplier;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * A container for values which provided by {@code ThrowableSupplier}.
@@ -38,7 +41,8 @@ public class Exceptional<T> {
      * @param supplier  a supplier function
      * @return an {@code Exceptional}
      */
-    public static <T> Exceptional<T> of(ThrowableSupplier<T, Throwable> supplier) {
+    @NotNull
+    public static <T> Exceptional<T> of(@NotNull ThrowableSupplier<T, Throwable> supplier) {
         try {
             return new Exceptional<T>(supplier.get(), null);
         } catch (Throwable throwable) {
@@ -53,14 +57,16 @@ public class Exceptional<T> {
      * @param throwable  throwable instance
      * @return an {@code Exceptional}
      */
-    public static <T> Exceptional<T> of(Throwable throwable) {
+    @NotNull
+    @Contract("_ -> new")
+    public static <T> Exceptional<T> of(@NotNull Throwable throwable) {
         return new Exceptional<T>(null, throwable);
     }
 
     private final T value;
     private final Throwable throwable;
 
-    private Exceptional(T value, Throwable throwable) {
+    private Exceptional(@Nullable T value, @Nullable Throwable throwable) {
         this.value = value;
         this.throwable = throwable;
     }
@@ -70,6 +76,7 @@ public class Exceptional<T> {
      *
      * @return inner value.
      */
+    @Nullable
     public T get() {
         return value;
     }
@@ -89,7 +96,8 @@ public class Exceptional<T> {
      * @param other  the value to be returned if there were any exception
      * @return inner value if there were no exceptions, otherwise {@code other}
      */
-    public T getOrElse(T other) {
+    @Nullable
+    public T getOrElse(@Nullable T other) {
         return throwable == null ? value : other;
     }
 
@@ -100,7 +108,8 @@ public class Exceptional<T> {
      * @return inner value if there were no exceptions, otherwise value produced by supplier function
      * @since 1.1.9
      */
-    public T getOrElse(Supplier<? extends T> other) {
+    @Nullable
+    public T getOrElse(@NotNull Supplier<? extends T> other) {
         return throwable == null ? value : other.get();
     }
 
@@ -109,6 +118,7 @@ public class Exceptional<T> {
      *
      * @return an {@code Optional}
      */
+    @NotNull
     public Optional<T> getOptional() {
         return Optional.ofNullable(value);
     }
@@ -118,6 +128,7 @@ public class Exceptional<T> {
      *
      * @return exception
      */
+    @Nullable
     public Throwable getException() {
         return throwable;
     }
@@ -128,6 +139,7 @@ public class Exceptional<T> {
      * @return inner value if there were no exceptions
      * @throws Throwable that was thrown in supplier function
      */
+    @Nullable
     public T getOrThrow() throws Throwable {
         if (throwable != null) {
             throw throwable;
@@ -141,6 +153,7 @@ public class Exceptional<T> {
      * @return inner value if there were no exceptions
      * @throws RuntimeException with wrapped exception which was thrown in supplier function
      */
+    @Nullable
     public T getOrThrowRuntimeException() throws RuntimeException {
         if (throwable != null) {
             throw new RuntimeException(throwable);
@@ -156,7 +169,8 @@ public class Exceptional<T> {
      * @return inner value if there were no exceptions
      * @throws E if there were exceptions in supplier function
      */
-    public <E extends Throwable> T getOrThrow(E exception) throws E {
+    @Nullable
+    public <E extends Throwable> T getOrThrow(@NotNull E exception) throws E {
         if (throwable != null) {
             exception.initCause(throwable);
             throw exception;
@@ -173,7 +187,8 @@ public class Exceptional<T> {
      *         an {@code Exceptional} produced by supplier function
      * @throws NullPointerException if {@code supplier} or its result is null
      */
-    public Exceptional<T> or(Supplier<Exceptional<T>> supplier) {
+    @NotNull
+    public Exceptional<T> or(@NotNull Supplier<Exceptional<T>> supplier) {
         if (throwable == null) return this;
 
         Objects.requireNonNull(supplier);
@@ -189,7 +204,8 @@ public class Exceptional<T> {
      * @throws NullPointerException if {@code function} is null
      * @since 1.1.9
      */
-    public <R> R custom(Function<Exceptional<T>, R> function) {
+    @Nullable
+    public <R> R custom(@NotNull Function<Exceptional<T>, R> function) {
         Objects.requireNonNull(function);
         return function.apply(this);
     }
@@ -202,7 +218,8 @@ public class Exceptional<T> {
      * @return an {@code Exceptional} with transformed value if there were no exceptions
      * @throws NullPointerException if {@code mapper} is null
      */
-    public <U> Exceptional<U> map(ThrowableFunction<? super T, ? extends U, Throwable> mapper) {
+    @NotNull
+    public <U> Exceptional<U> map(@NotNull ThrowableFunction<? super T, ? extends U, Throwable> mapper) {
         if (throwable != null) {
             return of(throwable);
         }
@@ -221,7 +238,8 @@ public class Exceptional<T> {
      * @return this {@code Exceptional}
      * @since 1.1.2
      */
-    public Exceptional<T> ifPresent(Consumer<? super T> consumer) {
+    @NotNull
+    public Exceptional<T> ifPresent(@NotNull Consumer<? super T> consumer) {
         if (throwable == null) {
             consumer.accept(value);
         }
@@ -234,7 +252,8 @@ public class Exceptional<T> {
      * @param consumer  a consumer function
      * @return an {@code Exceptional}
      */
-    public Exceptional<T> ifException(Consumer<Throwable> consumer) {
+    @NotNull
+    public Exceptional<T> ifException(@NotNull Consumer<Throwable> consumer) {
         if (throwable != null) {
             consumer.accept(throwable);
         }
@@ -249,8 +268,9 @@ public class Exceptional<T> {
      * @param consumer  a consumer function
      * @return an {@code Exceptional}
      */
+    @NotNull
     @SuppressWarnings("unchecked")
-    public <E extends Throwable> Exceptional<T> ifExceptionIs(Class<E> throwableClass, Consumer<? super E> consumer) {
+    public <E extends Throwable> Exceptional<T> ifExceptionIs(@NotNull Class<E> throwableClass, @NotNull Consumer<? super E> consumer) {
         if ( (throwable != null) &&
                 (throwableClass.isAssignableFrom(throwable.getClass())) ) {
             consumer.accept((E) throwable);
@@ -268,7 +288,8 @@ public class Exceptional<T> {
      * @throws NullPointerException if {@code function} is null
      * @since 1.1.2
      */
-    public Exceptional<T> recover(final ThrowableFunction<Throwable, ? extends T, Throwable> function) {
+    @NotNull
+    public Exceptional<T> recover(@NotNull final ThrowableFunction<Throwable, ? extends T, Throwable> function) {
         if (throwable == null) return this;
 
         Objects.requireNonNull(function);
@@ -289,7 +310,8 @@ public class Exceptional<T> {
      * @throws NullPointerException if {@code function} or produced result is null
      * @since 1.1.2
      */
-    public Exceptional<T> recoverWith(final Function<Throwable, ? extends Exceptional<T>> function) {
+    @NotNull
+    public Exceptional<T> recoverWith(@NotNull final Function<Throwable, ? extends Exceptional<T>> function) {
         if (throwable == null) return this;
 
         Objects.requireNonNull(function);
@@ -316,6 +338,7 @@ public class Exceptional<T> {
         return Objects.hash(value, throwable);
     }
 
+    @NotNull
     @Override
     public String toString() {
         return throwable == null

--- a/stream/src/main/java/com/annimon/stream/IntStream.java
+++ b/stream/src/main/java/com/annimon/stream/IntStream.java
@@ -10,6 +10,8 @@ import com.annimon.stream.operator.*;
 import java.io.Closeable;
 import java.util.Comparator;
 import java.util.NoSuchElementException;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * A sequence of primitive int-valued elements supporting sequential operations. This is the {@code int}
@@ -38,6 +40,7 @@ public final class IntStream implements Closeable {
      *
      * @return the empty stream
      */
+    @NotNull
     public static IntStream empty() {
         return EMPTY;
     }
@@ -49,7 +52,8 @@ public final class IntStream implements Closeable {
      * @return the new {@code IntStream}
      * @throws NullPointerException if {@code iterator} is null
      */
-    public static IntStream of(PrimitiveIterator.OfInt iterator) {
+    @NotNull
+    public static IntStream of(@NotNull PrimitiveIterator.OfInt iterator) {
         Objects.requireNonNull(iterator);
         return new IntStream(iterator);
     }
@@ -61,7 +65,8 @@ public final class IntStream implements Closeable {
      * @return the new stream
      * @throws NullPointerException if {@code values} is null
      */
-    public static IntStream of(final int... values) {
+    @NotNull
+    public static IntStream of(@NotNull final int... values) {
         Objects.requireNonNull(values);
         if (values.length == 0) {
             return IntStream.empty();
@@ -75,6 +80,7 @@ public final class IntStream implements Closeable {
      * @param t element of the stream
      * @return the new stream
      */
+    @NotNull
     public static IntStream of(final int t) {
         return new IntStream(new IntArray(new int[] { t }));
     }
@@ -91,7 +97,8 @@ public final class IntStream implements Closeable {
      * @return the new stream
      * @since 1.1.8
      */
-    public static IntStream ofCodePoints(CharSequence charSequence) {
+    @NotNull
+    public static IntStream ofCodePoints(@NotNull CharSequence charSequence) {
         return new IntStream(new IntCodePoints(charSequence));
     }
 
@@ -105,6 +112,7 @@ public final class IntStream implements Closeable {
      * @return a sequential {@code IntStream} for the range of {@code int}
      *         elements
      */
+    @NotNull
     public static IntStream range(final int startInclusive, final int endExclusive) {
         if (startInclusive >= endExclusive) {
             return empty();
@@ -122,6 +130,7 @@ public final class IntStream implements Closeable {
      * @return a sequential {@code IntStream} for the range of {@code int}
      *         elements
      */
+    @NotNull
     public static IntStream rangeClosed(final int startInclusive, final int endInclusive) {
         if (startInclusive > endInclusive) {
             return empty();
@@ -141,7 +150,8 @@ public final class IntStream implements Closeable {
      * @return a new infinite sequential {@code IntStream}
      * @throws NullPointerException if {@code s} is null
      */
-    public static IntStream generate(final IntSupplier s) {
+    @NotNull
+    public static IntStream generate(@NotNull final IntSupplier s) {
         Objects.requireNonNull(s);
         return new IntStream(new IntGenerate(s));
     }
@@ -170,7 +180,9 @@ public final class IntStream implements Closeable {
      * @return a new sequential {@code IntStream}
      * @throws NullPointerException if {@code f} is null
      */
-    public static IntStream iterate(final int seed, final IntUnaryOperator f) {
+    @NotNull
+    public static IntStream iterate(final int seed,
+                                    @NotNull final IntUnaryOperator f) {
         Objects.requireNonNull(f);
         return new IntStream(new IntIterate(seed, f));
     }
@@ -194,8 +206,11 @@ public final class IntStream implements Closeable {
      * @throws NullPointerException if {@code op} is null
      * @since 1.1.5
      */
-    public static IntStream iterate(final int seed,
-            final IntPredicate predicate, final IntUnaryOperator op) {
+    @NotNull
+    public static IntStream iterate(
+            final int seed,
+            @NotNull final IntPredicate predicate,
+            @NotNull final IntUnaryOperator op) {
         Objects.requireNonNull(predicate);
         return iterate(seed, op).takeWhile(predicate);
     }
@@ -217,7 +232,10 @@ public final class IntStream implements Closeable {
      * @return the concatenation of the two input streams
      * @throws NullPointerException if {@code a} or {@code b} is null
      */
-    public static IntStream concat(final IntStream a, final IntStream b) {
+    @NotNull
+    public static IntStream concat(
+            @NotNull final IntStream a,
+            @NotNull final IntStream b) {
         Objects.requireNonNull(a);
         Objects.requireNonNull(b);
         IntStream result = new IntStream(new IntConcat(a.iterator, b.iterator));
@@ -311,7 +329,8 @@ public final class IntStream implements Closeable {
      * @see Stream#custom(com.annimon.stream.function.Function)
      * @throws NullPointerException if {@code function} is null
      */
-    public <R> R custom(final Function<IntStream, R> function) {
+    @Nullable
+    public <R> R custom(@NotNull final Function<IntStream, R> function) {
         Objects.requireNonNull(function);
         return function.apply(this);
     }
@@ -325,6 +344,7 @@ public final class IntStream implements Closeable {
      * @return a {@code Stream} consistent of the elements of this stream,
      *         each boxed to an {@code Integer}
      */
+    @NotNull
     public Stream<Integer> boxed() {
         return new Stream<Integer>(params, iterator);
     }
@@ -346,7 +366,8 @@ public final class IntStream implements Closeable {
      *                  element to determine if it should be included
      * @return the new stream
      */
-    public IntStream filter(final IntPredicate predicate) {
+    @NotNull
+    public IntStream filter(@NotNull final IntPredicate predicate) {
         return new IntStream(params, new IntFilter(iterator, predicate));
     }
 
@@ -369,7 +390,8 @@ public final class IntStream implements Closeable {
      * @return the new stream
      * @since 1.2.1
      */
-    public IntStream filterIndexed(IndexedIntPredicate predicate) {
+    @NotNull
+    public IntStream filterIndexed(@NotNull IndexedIntPredicate predicate) {
         return filterIndexed(0, 1, predicate);
     }
 
@@ -396,7 +418,9 @@ public final class IntStream implements Closeable {
      * @return the new stream
      * @since 1.2.1
      */
-    public IntStream filterIndexed(int from, int step, IndexedIntPredicate predicate) {
+    @NotNull
+    public IntStream filterIndexed(int from, int step,
+                                   @NotNull IndexedIntPredicate predicate) {
         return new IntStream(params, new IntFilterIndexed(
                 new PrimitiveIndexedIterator.OfInt(from, step, iterator),
                 predicate));
@@ -412,7 +436,8 @@ public final class IntStream implements Closeable {
      *                  element to determine if it should not be included
      * @return the new stream
      */
-    public IntStream filterNot(final IntPredicate predicate) {
+    @NotNull
+    public IntStream filterNot(@NotNull final IntPredicate predicate) {
         return filter(IntPredicate.Util.negate(predicate));
     }
 
@@ -433,7 +458,8 @@ public final class IntStream implements Closeable {
      *               each element
      * @return the new {@code IntStream}
      */
-    public IntStream map(final IntUnaryOperator mapper) {
+    @NotNull
+    public IntStream map(@NotNull final IntUnaryOperator mapper) {
         return new IntStream(params, new IntMap(iterator, mapper));
     }
 
@@ -454,7 +480,8 @@ public final class IntStream implements Closeable {
      * @return the new stream
      * @since 1.2.1
      */
-    public IntStream mapIndexed(IntBinaryOperator mapper) {
+    @NotNull
+    public IntStream mapIndexed(@NotNull IntBinaryOperator mapper) {
         return mapIndexed(0, 1, mapper);
     }
 
@@ -479,7 +506,9 @@ public final class IntStream implements Closeable {
      * @return the new stream
      * @since 1.2.1
      */
-    public IntStream mapIndexed(int from, int step, IntBinaryOperator mapper) {
+    @NotNull
+    public IntStream mapIndexed(int from, int step,
+                                @NotNull IntBinaryOperator mapper) {
         return new IntStream(params, new IntMapIndexed(
                 new PrimitiveIndexedIterator.OfInt(from, step, iterator),
                 mapper));
@@ -495,7 +524,8 @@ public final class IntStream implements Closeable {
      * @param mapper the mapper function used to apply to each element
      * @return the new {@code Stream}
      */
-    public <R> Stream<R> mapToObj(final IntFunction<? extends R> mapper) {
+    @NotNull
+    public <R> Stream<R> mapToObj(@NotNull final IntFunction<? extends R> mapper) {
         return new Stream<R>(params, new IntMapToObj<R>(iterator, mapper));
     }
 
@@ -510,7 +540,8 @@ public final class IntStream implements Closeable {
      * @since 1.1.4
      * @see #flatMap(com.annimon.stream.function.IntFunction)
      */
-    public LongStream mapToLong(final IntToLongFunction mapper) {
+    @NotNull
+    public LongStream mapToLong(@NotNull final IntToLongFunction mapper) {
         return new LongStream(params, new IntMapToLong(iterator, mapper));
     }
 
@@ -525,7 +556,8 @@ public final class IntStream implements Closeable {
      * @since 1.1.4
      * @see #flatMap(com.annimon.stream.function.IntFunction)
      */
-    public DoubleStream mapToDouble(final IntToDoubleFunction mapper) {
+    @NotNull
+    public DoubleStream mapToDouble(@NotNull final IntToDoubleFunction mapper) {
         return new DoubleStream(params, new IntMapToDouble(iterator, mapper));
     }
 
@@ -548,7 +580,8 @@ public final class IntStream implements Closeable {
      * @return the new stream
      * @see Stream#flatMap(Function)
      */
-    public IntStream flatMap(final IntFunction<? extends IntStream> mapper) {
+    @NotNull
+    public IntStream flatMap(@NotNull final IntFunction<? extends IntStream> mapper) {
         return new IntStream(params, new IntFlatMap(iterator, mapper));
     }
 
@@ -565,6 +598,7 @@ public final class IntStream implements Closeable {
      *
      * @return the new stream
      */
+    @NotNull
     public IntStream distinct() {
         // While functional and quick to implement, this approach is not very efficient.
         // An efficient version requires an int-specific map/set implementation.
@@ -585,6 +619,7 @@ public final class IntStream implements Closeable {
      *
      * @return the new stream
      */
+    @NotNull
     public IntStream sorted() {
         return new IntStream(params, new IntSorted(iterator));
     }
@@ -604,7 +639,8 @@ public final class IntStream implements Closeable {
      * @param comparator  the {@code Comparator} to compare elements
      * @return the new {@code IntStream}
      */
-    public IntStream sorted(Comparator<Integer> comparator) {
+    @NotNull
+    public IntStream sorted(@NotNull Comparator<Integer> comparator) {
         return boxed().sorted(comparator).mapToInt(UNBOX_FUNCTION);
     }
 
@@ -625,6 +661,7 @@ public final class IntStream implements Closeable {
      * @throws IllegalArgumentException if {@code stepWidth} is zero or negative
      * @see Stream#sample(int)
      */
+    @NotNull
     public IntStream sample(final int stepWidth) {
         if (stepWidth <= 0) throw new IllegalArgumentException("stepWidth cannot be zero or negative");
         if (stepWidth == 1) return this;
@@ -641,7 +678,8 @@ public final class IntStream implements Closeable {
      * @param action the action to be performed on each element
      * @return the new stream
      */
-    public IntStream peek(final IntConsumer action) {
+    @NotNull
+    public IntStream peek(@NotNull final IntConsumer action) {
         return new IntStream(params, new IntPeek(iterator, action));
     }
 
@@ -665,7 +703,8 @@ public final class IntStream implements Closeable {
      * @throws NullPointerException if {@code accumulator} is null
      * @since 1.1.6
      */
-    public IntStream scan(final IntBinaryOperator accumulator) {
+    @NotNull
+    public IntStream scan(@NotNull final IntBinaryOperator accumulator) {
         Objects.requireNonNull(accumulator);
         return new IntStream(params, new IntScan(iterator, accumulator));
     }
@@ -692,7 +731,9 @@ public final class IntStream implements Closeable {
      * @throws NullPointerException if {@code accumulator} is null
      * @since 1.1.6
      */
-    public IntStream scan(final int identity, final IntBinaryOperator accumulator) {
+    @NotNull
+    public IntStream scan(final int identity,
+                          @NotNull final IntBinaryOperator accumulator) {
         Objects.requireNonNull(accumulator);
         return new IntStream(params, new IntScanIdentity(iterator, identity, accumulator));
     }
@@ -712,7 +753,8 @@ public final class IntStream implements Closeable {
      * @param predicate  the predicate used to take elements
      * @return the new {@code IntStream}
      */
-    public IntStream takeWhile(final IntPredicate predicate) {
+    @NotNull
+    public IntStream takeWhile(@NotNull final IntPredicate predicate) {
         return new IntStream(params, new IntTakeWhile(iterator, predicate));
     }
 
@@ -734,7 +776,8 @@ public final class IntStream implements Closeable {
      * @return the new {@code IntStream}
      * @since 1.1.6
      */
-    public IntStream takeUntil(final IntPredicate stopPredicate) {
+    @NotNull
+    public IntStream takeUntil(@NotNull final IntPredicate stopPredicate) {
         return new IntStream(params, new IntTakeUntil(iterator, stopPredicate));
     }
 
@@ -753,7 +796,8 @@ public final class IntStream implements Closeable {
      * @param predicate  the predicate used to drop elements
      * @return the new {@code IntStream}
      */
-    public IntStream dropWhile(final IntPredicate predicate) {
+    @NotNull
+    public IntStream dropWhile(@NotNull final IntPredicate predicate) {
         return new IntStream(params, new IntDropWhile(iterator, predicate));
     }
 
@@ -778,6 +822,7 @@ public final class IntStream implements Closeable {
      * @return the new stream
      * @throws IllegalArgumentException if {@code maxSize} is negative
      */
+    @NotNull
     public IntStream limit(final long maxSize) {
         if (maxSize < 0) {
             throw new IllegalArgumentException("maxSize cannot be negative");
@@ -811,6 +856,7 @@ public final class IntStream implements Closeable {
      * @return the new stream
      * @throws IllegalArgumentException if {@code n} is negative
      */
+    @NotNull
     public IntStream skip(final long n) {
         if (n < 0) {
             throw new IllegalArgumentException("n cannot be negative");
@@ -828,7 +874,7 @@ public final class IntStream implements Closeable {
      *
      * @param action a non-interfering action to perform on the elements
      */
-    public void forEach(IntConsumer action) {
+    public void forEach(@NotNull IntConsumer action) {
         while(iterator.hasNext()) {
             action.accept(iterator.nextInt());
         }
@@ -842,7 +888,7 @@ public final class IntStream implements Closeable {
      * @param action  the action to be performed on each element
      * @since 1.2.1
      */
-    public void forEachIndexed(IndexedIntConsumer action) {
+    public void forEachIndexed(@NotNull IndexedIntConsumer action) {
         forEachIndexed(0, 1, action);
     }
 
@@ -856,7 +902,8 @@ public final class IntStream implements Closeable {
      * @param action  the action to be performed on each element
      * @since 1.2.1
      */
-    public void forEachIndexed(int from, int step, IndexedIntConsumer action) {
+    public void forEachIndexed(int from, int step,
+                               @NotNull IndexedIntConsumer action) {
         int index = from;
         while (iterator.hasNext()) {
             action.accept(index, iterator.nextInt());
@@ -892,7 +939,7 @@ public final class IntStream implements Closeable {
      * @see #min()
      * @see #max()
      */
-    public int reduce(int identity, IntBinaryOperator op) {
+    public int reduce(int identity, @NotNull IntBinaryOperator op) {
         int result = identity;
         while(iterator.hasNext()) {
             int value = iterator.nextInt();
@@ -915,7 +962,8 @@ public final class IntStream implements Closeable {
      * @return the result of the reduction
      * @see #reduce(int, IntBinaryOperator)
      */
-    public OptionalInt reduce(IntBinaryOperator op) {
+    @NotNull
+    public OptionalInt reduce(@NotNull IntBinaryOperator op) {
         boolean foundAny = false;
         int result = 0;
         while(iterator.hasNext()) {
@@ -938,6 +986,7 @@ public final class IntStream implements Closeable {
      *
      * @return an array containing the elements of this stream
      */
+    @NotNull
     public int[] toArray() {
         return Operators.toIntArray(iterator);
     }
@@ -953,7 +1002,9 @@ public final class IntStream implements Closeable {
      * @return the result of collect elements
      * @see Stream#collect(com.annimon.stream.function.Supplier, com.annimon.stream.function.BiConsumer)
      */
-    public <R> R collect(Supplier<R> supplier, ObjIntConsumer<R> accumulator) {
+    @Nullable
+    public <R> R collect(@NotNull Supplier<R> supplier,
+                         @NotNull ObjIntConsumer<R> accumulator) {
         R result = supplier.get();
         while (iterator.hasNext()) {
             final int value = iterator.nextInt();
@@ -985,6 +1036,7 @@ public final class IntStream implements Closeable {
      * @return an {@code OptionalInt} containing the minimum element of this
      *         stream, or an empty {@code OptionalInt} if the stream is empty
      */
+    @NotNull
     public OptionalInt min() {
         return reduce(new IntBinaryOperator() {
             @Override
@@ -1003,6 +1055,7 @@ public final class IntStream implements Closeable {
      * @return an {@code OptionalInt} containing the maximum element of this
      *         stream, or an empty {@code OptionalInt} if the stream is empty
      */
+    @NotNull
     public OptionalInt max() {
         return reduce(new IntBinaryOperator() {
             @Override
@@ -1052,7 +1105,7 @@ public final class IntStream implements Closeable {
      * @return {@code true} if any elements of the stream match the provided
      *         predicate, otherwise {@code false}
      */
-    public boolean anyMatch(IntPredicate predicate) {
+    public boolean anyMatch(@NotNull IntPredicate predicate) {
         while(iterator.hasNext()) {
             if(predicate.test(iterator.nextInt()))
                 return true;
@@ -1085,7 +1138,7 @@ public final class IntStream implements Closeable {
      * @return {@code true} if either all elements of the stream match the
      *         provided predicate or the stream is empty, otherwise {@code false}
      */
-    public boolean allMatch(IntPredicate predicate) {
+    public boolean allMatch(@NotNull IntPredicate predicate) {
         while(iterator.hasNext()) {
             if(!predicate.test(iterator.nextInt()))
                 return false;
@@ -1118,7 +1171,7 @@ public final class IntStream implements Closeable {
      * @return {@code true} if either no elements of the stream match the
      *         provided predicate or the stream is empty, otherwise {@code false}
      */
-    public boolean noneMatch(IntPredicate predicate) {
+    public boolean noneMatch(@NotNull IntPredicate predicate) {
         while (iterator.hasNext()) {
             if (predicate.test(iterator.nextInt()))
                 return false;
@@ -1135,6 +1188,7 @@ public final class IntStream implements Closeable {
      * @return an {@code OptionalInt} describing the first element of this stream,
      *         or an empty {@code OptionalInt} if the stream is empty
      */
+    @NotNull
     public OptionalInt findFirst() {
         if (iterator.hasNext()) {
             return OptionalInt.of(iterator.nextInt());
@@ -1153,6 +1207,7 @@ public final class IntStream implements Closeable {
      *         or {@code OptionalInt.empty()} if the stream is empty
      * @since 1.1.8
      */
+    @NotNull
     public OptionalInt findLast() {
         return reduce(new IntBinaryOperator() {
             @Override
@@ -1222,6 +1277,7 @@ public final class IntStream implements Closeable {
      * @throws IllegalStateException if stream contains more than one element
      * @since 1.1.3
      */
+    @NotNull
     public OptionalInt findSingle() {
         if (iterator.hasNext()) {
             int singleCandidate = iterator.nextInt();
@@ -1244,7 +1300,8 @@ public final class IntStream implements Closeable {
      * @return the new stream with the close handler
      * @since 1.1.8
      */
-    public IntStream onClose(final Runnable closeHandler) {
+    @NotNull
+    public IntStream onClose(@NotNull final Runnable closeHandler) {
         Objects.requireNonNull(closeHandler);
         final Params newParams;
         if (params == null) {

--- a/stream/src/main/java/com/annimon/stream/IntStream.java
+++ b/stream/src/main/java/com/annimon/stream/IntStream.java
@@ -640,7 +640,7 @@ public final class IntStream implements Closeable {
      * @return the new {@code IntStream}
      */
     @NotNull
-    public IntStream sorted(@NotNull Comparator<Integer> comparator) {
+    public IntStream sorted(@Nullable Comparator<Integer> comparator) {
         return boxed().sorted(comparator).mapToInt(UNBOX_FUNCTION);
     }
 

--- a/stream/src/main/java/com/annimon/stream/LongStream.java
+++ b/stream/src/main/java/com/annimon/stream/LongStream.java
@@ -10,6 +10,8 @@ import com.annimon.stream.operator.*;
 import java.io.Closeable;
 import java.util.Comparator;
 import java.util.NoSuchElementException;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * A sequence of {@code long}-valued elements supporting aggregate operations.
@@ -41,6 +43,7 @@ public final class LongStream implements Closeable {
      *
      * @return the empty stream
      */
+    @NotNull
     public static LongStream empty() {
         return EMPTY;
     }
@@ -52,7 +55,8 @@ public final class LongStream implements Closeable {
      * @return the new {@code LongStream}
      * @throws NullPointerException if {@code iterator} is null
      */
-    public static LongStream of(PrimitiveIterator.OfLong iterator) {
+    @NotNull
+    public static LongStream of(@NotNull PrimitiveIterator.OfLong iterator) {
         Objects.requireNonNull(iterator);
         return new LongStream(iterator);
     }
@@ -64,7 +68,8 @@ public final class LongStream implements Closeable {
      * @return the new stream
      * @throws NullPointerException if {@code values} is null
      */
-    public static LongStream of(final long... values) {
+    @NotNull
+    public static LongStream of(@NotNull final long... values) {
         Objects.requireNonNull(values);
         if (values.length == 0) {
             return LongStream.empty();
@@ -78,6 +83,7 @@ public final class LongStream implements Closeable {
      * @param t  element of the stream
      * @return the new stream
      */
+    @NotNull
     public static LongStream of(final long t) {
         return new LongStream(new LongArray(new long[] { t }));
     }
@@ -92,6 +98,7 @@ public final class LongStream implements Closeable {
      * @return a sequential {@code LongStream} for the range of {@code long}
      *         elements
      */
+    @NotNull
     public static LongStream range(final long startInclusive, final long endExclusive) {
         if (startInclusive >= endExclusive) {
             return empty();
@@ -109,6 +116,7 @@ public final class LongStream implements Closeable {
      * @return a sequential {@code LongStream} for the range of {@code long}
      *         elements
      */
+    @NotNull
     public static LongStream rangeClosed(final long startInclusive, final long endInclusive) {
         if (startInclusive > endInclusive) {
             return empty();
@@ -124,7 +132,8 @@ public final class LongStream implements Closeable {
      * @return a new infinite sequential {@code LongStream}
      * @throws NullPointerException if {@code s} is null
      */
-    public static LongStream generate(final LongSupplier s) {
+    @NotNull
+    public static LongStream generate(@NotNull final LongSupplier s) {
         Objects.requireNonNull(s);
         return new LongStream(new LongGenerate(s));
     }
@@ -151,7 +160,9 @@ public final class LongStream implements Closeable {
      * @return a new sequential {@code LongStream}
      * @throws NullPointerException if {@code f} is null
      */
-    public static LongStream iterate(final long seed, final LongUnaryOperator f) {
+    @NotNull
+    public static LongStream iterate(final long seed,
+                                     @NotNull final LongUnaryOperator f) {
         Objects.requireNonNull(f);
         return new LongStream(new LongIterate(seed, f));
     }
@@ -175,8 +186,11 @@ public final class LongStream implements Closeable {
      * @throws NullPointerException if {@code op} is null
      * @since 1.1.5
      */
-    public static LongStream iterate(final long seed,
-            final LongPredicate predicate, final LongUnaryOperator op) {
+    @NotNull
+    public static LongStream iterate(
+            final long seed,
+            @NotNull final LongPredicate predicate,
+            @NotNull final LongUnaryOperator op) {
         Objects.requireNonNull(predicate);
         return iterate(seed, op).takeWhile(predicate);
     }
@@ -196,7 +210,10 @@ public final class LongStream implements Closeable {
      * @return the new concatenated stream
      * @throws NullPointerException if {@code a} or {@code b} is null
      */
-    public static LongStream concat(final LongStream a, final LongStream b) {
+    @NotNull
+    public static LongStream concat(
+            @NotNull final LongStream a,
+            @NotNull final LongStream b) {
         Objects.requireNonNull(a);
         Objects.requireNonNull(b);
         LongStream result = new LongStream(new LongConcat(a.iterator, b.iterator));
@@ -300,7 +317,8 @@ public final class LongStream implements Closeable {
      * @see Stream#custom(com.annimon.stream.function.Function)
      * @throws NullPointerException if {@code function} is null
      */
-    public <R> R custom(final Function<LongStream, R> function) {
+    @Nullable
+    public <R> R custom(@NotNull final Function<LongStream, R> function) {
         Objects.requireNonNull(function);
         return function.apply(this);
     }
@@ -314,6 +332,7 @@ public final class LongStream implements Closeable {
      * @return a {@code Stream} consistent of the elements of this stream,
      *         each boxed to an {@code Long}
      */
+    @NotNull
     public Stream<Long> boxed() {
         return new Stream<Long>(params, iterator);
     }
@@ -333,7 +352,8 @@ public final class LongStream implements Closeable {
      * @param predicate  the predicate used to filter elements
      * @return the new stream
      */
-    public LongStream filter(final LongPredicate predicate) {
+    @NotNull
+    public LongStream filter(@NotNull final LongPredicate predicate) {
         return new LongStream(params, new LongFilter(iterator, predicate));
     }
 
@@ -356,7 +376,8 @@ public final class LongStream implements Closeable {
      * @return the new stream
      * @since 1.2.1
      */
-    public LongStream filterIndexed(IndexedLongPredicate predicate) {
+    @NotNull
+    public LongStream filterIndexed(@NotNull IndexedLongPredicate predicate) {
         return filterIndexed(0, 1, predicate);
     }
 
@@ -383,7 +404,9 @@ public final class LongStream implements Closeable {
      * @return the new stream
      * @since 1.2.1
      */
-    public LongStream filterIndexed(int from, int step, IndexedLongPredicate predicate) {
+    @NotNull
+    public LongStream filterIndexed(int from, int step,
+                                    @NotNull IndexedLongPredicate predicate) {
         return new LongStream(params, new LongFilterIndexed(
                 new PrimitiveIndexedIterator.OfLong(from, step, iterator),
                 predicate));
@@ -397,7 +420,8 @@ public final class LongStream implements Closeable {
      * @param predicate  the predicate used to filter elements
      * @return the new stream
      */
-    public LongStream filterNot(final LongPredicate predicate) {
+    @NotNull
+    public LongStream filterNot(@NotNull final LongPredicate predicate) {
         return filter(LongPredicate.Util.negate(predicate));
     }
 
@@ -418,7 +442,8 @@ public final class LongStream implements Closeable {
      * @return the new stream
      * @see Stream#map(com.annimon.stream.function.Function)
      */
-    public LongStream map(final LongUnaryOperator mapper) {
+    @NotNull
+    public LongStream map(@NotNull final LongUnaryOperator mapper) {
         return new LongStream(params, new LongMap(iterator, mapper));
     }
 
@@ -440,7 +465,8 @@ public final class LongStream implements Closeable {
      * @return the new stream
      * @since 1.2.1
      */
-    public LongStream mapIndexed(IndexedLongUnaryOperator mapper) {
+    @NotNull
+    public LongStream mapIndexed(@NotNull IndexedLongUnaryOperator mapper) {
         return mapIndexed(0, 1, mapper);
     }
 
@@ -466,7 +492,9 @@ public final class LongStream implements Closeable {
      * @return the new stream
      * @since 1.2.1
      */
-    public LongStream mapIndexed(int from, int step, IndexedLongUnaryOperator mapper) {
+    @NotNull
+    public LongStream mapIndexed(int from, int step,
+                                 @NotNull IndexedLongUnaryOperator mapper) {
         return new LongStream(params, new LongMapIndexed(
                 new PrimitiveIndexedIterator.OfLong(from, step, iterator),
                 mapper));
@@ -482,7 +510,8 @@ public final class LongStream implements Closeable {
      * @param mapper  the mapper function used to apply to each element
      * @return the new {@code Stream}
      */
-    public <R> Stream<R> mapToObj(final LongFunction<? extends R> mapper) {
+    @NotNull
+    public <R> Stream<R> mapToObj(@NotNull final LongFunction<? extends R> mapper) {
         return new Stream<R>(params, new LongMapToObj<R>(iterator, mapper));
     }
 
@@ -495,7 +524,8 @@ public final class LongStream implements Closeable {
      * @param mapper  the mapper function used to apply to each element
      * @return the new {@code IntStream}
      */
-    public IntStream mapToInt(final LongToIntFunction mapper) {
+    @NotNull
+    public IntStream mapToInt(@NotNull final LongToIntFunction mapper) {
         return new IntStream(params, new LongMapToInt(iterator, mapper));
     }
 
@@ -508,7 +538,8 @@ public final class LongStream implements Closeable {
      * @param mapper  the mapper function used to apply to each element
      * @return the new {@code DoubleStream}
      */
-    public DoubleStream mapToDouble(final LongToDoubleFunction mapper) {
+    @NotNull
+    public DoubleStream mapToDouble(@NotNull final LongToDoubleFunction mapper) {
         return new DoubleStream(params, new LongMapToDouble(iterator, mapper));
     }
 
@@ -530,7 +561,8 @@ public final class LongStream implements Closeable {
      * @return the new stream
      * @see Stream#flatMap(com.annimon.stream.function.Function)
      */
-    public LongStream flatMap(final LongFunction<? extends LongStream> mapper) {
+    @NotNull
+    public LongStream flatMap(@NotNull final LongFunction<? extends LongStream> mapper) {
         return new LongStream(params, new LongFlatMap(iterator, mapper));
     }
 
@@ -547,6 +579,7 @@ public final class LongStream implements Closeable {
      *
      * @return the new stream
      */
+    @NotNull
     public LongStream distinct() {
         return boxed().distinct().mapToLong(UNBOX_FUNCTION);
     }
@@ -564,6 +597,7 @@ public final class LongStream implements Closeable {
      *
      * @return the new stream
      */
+    @NotNull
     public LongStream sorted() {
         return new LongStream(params, new LongSorted(iterator));
     }
@@ -584,7 +618,8 @@ public final class LongStream implements Closeable {
      * @param comparator  the {@code Comparator} to compare elements
      * @return the new {@code LongStream}
      */
-    public LongStream sorted(Comparator<Long> comparator) {
+    @NotNull
+    public LongStream sorted(@NotNull Comparator<Long> comparator) {
         return boxed().sorted(comparator).mapToLong(UNBOX_FUNCTION);
     }
 
@@ -605,6 +640,7 @@ public final class LongStream implements Closeable {
      * @throws IllegalArgumentException if {@code stepWidth} is zero or negative
      * @see Stream#sample(int)
      */
+    @NotNull
     public LongStream sample(final int stepWidth) {
         if (stepWidth <= 0) throw new IllegalArgumentException("stepWidth cannot be zero or negative");
         if (stepWidth == 1) return this;
@@ -619,7 +655,8 @@ public final class LongStream implements Closeable {
      * @param action the action to be performed on each element
      * @return the new stream
      */
-    public LongStream peek(final LongConsumer action) {
+    @NotNull
+    public LongStream peek(@NotNull final LongConsumer action) {
         return new LongStream(params, new LongPeek(iterator, action));
     }
 
@@ -643,7 +680,8 @@ public final class LongStream implements Closeable {
      * @throws NullPointerException if {@code accumulator} is null
      * @since 1.1.6
      */
-    public LongStream scan(final LongBinaryOperator accumulator) {
+    @NotNull
+    public LongStream scan(@NotNull final LongBinaryOperator accumulator) {
         Objects.requireNonNull(accumulator);
         return new LongStream(params, new LongScan(iterator, accumulator));
     }
@@ -670,7 +708,9 @@ public final class LongStream implements Closeable {
      * @throws NullPointerException if {@code accumulator} is null
      * @since 1.1.6
      */
-    public LongStream scan(final long identity, final LongBinaryOperator accumulator) {
+    @NotNull
+    public LongStream scan(final long identity,
+                           @NotNull final LongBinaryOperator accumulator) {
         Objects.requireNonNull(accumulator);
         return new LongStream(params, new LongScanIdentity(iterator, identity, accumulator));
     }
@@ -690,7 +730,8 @@ public final class LongStream implements Closeable {
      * @param predicate  the predicate used to take elements
      * @return the new {@code LongStream}
      */
-    public LongStream takeWhile(final LongPredicate predicate) {
+    @NotNull
+    public LongStream takeWhile(@NotNull final LongPredicate predicate) {
         return new LongStream(params, new LongTakeWhile(iterator, predicate));
     }
 
@@ -712,7 +753,8 @@ public final class LongStream implements Closeable {
      * @return the new {@code LongStream}
      * @since 1.1.6
      */
-    public LongStream takeUntil(final LongPredicate stopPredicate) {
+    @NotNull
+    public LongStream takeUntil(@NotNull final LongPredicate stopPredicate) {
         return new LongStream(params, new LongTakeUntil(iterator, stopPredicate));
     }
 
@@ -731,7 +773,8 @@ public final class LongStream implements Closeable {
      * @param predicate  the predicate used to drop elements
      * @return the new {@code LongStream}
      */
-    public LongStream dropWhile(final LongPredicate predicate) {
+    @NotNull
+    public LongStream dropWhile(@NotNull final LongPredicate predicate) {
         return new LongStream(params, new LongDropWhile(iterator, predicate));
     }
 
@@ -756,6 +799,7 @@ public final class LongStream implements Closeable {
      * @return the new stream
      * @throws IllegalArgumentException if {@code maxSize} is negative
      */
+    @NotNull
     public LongStream limit(final long maxSize) {
         if (maxSize < 0) throw new IllegalArgumentException("maxSize cannot be negative");
         if (maxSize == 0) return LongStream.empty();
@@ -784,6 +828,7 @@ public final class LongStream implements Closeable {
      * @return the new stream
      * @throws IllegalArgumentException if {@code n} is negative
      */
+    @NotNull
     public LongStream skip(final long n) {
         if (n < 0) throw new IllegalArgumentException("n cannot be negative");
         if (n == 0) return this;
@@ -797,7 +842,7 @@ public final class LongStream implements Closeable {
      *
      * @param action  the action to be performed on each element
      */
-    public void forEach(LongConsumer action) {
+    public void forEach(@NotNull LongConsumer action) {
         while (iterator.hasNext()) {
             action.accept(iterator.nextLong());
         }
@@ -811,7 +856,7 @@ public final class LongStream implements Closeable {
      * @param action  the action to be performed on each element
      * @since 1.2.1
      */
-    public void forEachIndexed(IndexedLongConsumer action) {
+    public void forEachIndexed(@NotNull IndexedLongConsumer action) {
         forEachIndexed(0, 1, action);
     }
 
@@ -825,7 +870,8 @@ public final class LongStream implements Closeable {
      * @param action  the action to be performed on each element
      * @since 1.2.1
      */
-    public void forEachIndexed(int from, int step, IndexedLongConsumer action) {
+    public void forEachIndexed(int from, int step,
+                               @NotNull IndexedLongConsumer action) {
         int index = from;
         while (iterator.hasNext()) {
             action.accept(index, iterator.nextLong());
@@ -860,7 +906,7 @@ public final class LongStream implements Closeable {
      * @see #min()
      * @see #max()
      */
-    public long reduce(long identity, LongBinaryOperator accumulator) {
+    public long reduce(long identity, @NotNull LongBinaryOperator accumulator) {
         long result = identity;
         while (iterator.hasNext()) {
             final long value = iterator.nextLong();
@@ -882,7 +928,8 @@ public final class LongStream implements Closeable {
      * @return the result of the reduction
      * @see #reduce(com.annimon.stream.function.LongBinaryOperator)
      */
-    public OptionalLong reduce(LongBinaryOperator accumulator) {
+    @NotNull
+    public OptionalLong reduce(@NotNull LongBinaryOperator accumulator) {
         boolean foundAny = false;
         long result = 0;
         while (iterator.hasNext()) {
@@ -904,6 +951,7 @@ public final class LongStream implements Closeable {
      *
      * @return an array containing the elements of this stream
      */
+    @NotNull
     public long[] toArray() {
         return Operators.toLongArray(iterator);
     }
@@ -919,7 +967,9 @@ public final class LongStream implements Closeable {
      * @return the result of collect elements
      * @see Stream#collect(com.annimon.stream.function.Supplier, com.annimon.stream.function.BiConsumer)
      */
-    public <R> R collect(Supplier<R> supplier, ObjLongConsumer<R> accumulator) {
+    @Nullable
+    public <R> R collect(@NotNull Supplier<R> supplier,
+                         @NotNull ObjLongConsumer<R> accumulator) {
         final R result = supplier.get();
         while (iterator.hasNext()) {
             final long value = iterator.nextLong();
@@ -949,6 +999,7 @@ public final class LongStream implements Closeable {
      *
      * @return the minimum element
      */
+    @NotNull
     public OptionalLong min() {
         return reduce(new LongBinaryOperator() {
             @Override
@@ -966,6 +1017,7 @@ public final class LongStream implements Closeable {
      *
      * @return the maximum element
      */
+    @NotNull
     public OptionalLong max() {
         return reduce(new LongBinaryOperator() {
             @Override
@@ -1014,7 +1066,7 @@ public final class LongStream implements Closeable {
      * @return {@code true} if any elements of the stream match the provided
      *         predicate, otherwise {@code false}
      */
-    public boolean anyMatch(LongPredicate predicate) {
+    public boolean anyMatch(@NotNull LongPredicate predicate) {
         while (iterator.hasNext()) {
             if (predicate.test(iterator.nextLong()))
                 return true;
@@ -1045,7 +1097,7 @@ public final class LongStream implements Closeable {
      * @return {@code true} if either all elements of the stream match the
      *         provided predicate or the stream is empty, otherwise {@code false}
      */
-    public boolean allMatch(LongPredicate predicate) {
+    public boolean allMatch(@NotNull LongPredicate predicate) {
         while (iterator.hasNext()) {
             if (!predicate.test(iterator.nextLong()))
                 return false;
@@ -1076,7 +1128,7 @@ public final class LongStream implements Closeable {
      * @return {@code true} if either no elements of the stream match the
      *         provided predicate or the stream is empty, otherwise {@code false}
      */
-    public boolean noneMatch(LongPredicate predicate) {
+    public boolean noneMatch(@NotNull LongPredicate predicate) {
         while (iterator.hasNext()) {
             if (predicate.test(iterator.nextLong()))
                 return false;
@@ -1093,6 +1145,7 @@ public final class LongStream implements Closeable {
      * @return an {@code OptionalLong} with first element
      *         or {@code OptionalLong.empty()} if stream is empty
      */
+    @NotNull
     public OptionalLong findFirst() {
         if (iterator.hasNext()) {
             return OptionalLong.of(iterator.nextLong());
@@ -1110,6 +1163,7 @@ public final class LongStream implements Closeable {
      *         or {@code OptionalLong.empty()} if the stream is empty
      * @since 1.1.8
      */
+    @NotNull
     public OptionalLong findLast() {
         return reduce(new LongBinaryOperator() {
             @Override
@@ -1177,6 +1231,7 @@ public final class LongStream implements Closeable {
      *         or {@code OptionalLong.empty()} if stream is empty
      * @throws IllegalStateException if stream contains more than one element
      */
+    @NotNull
     public OptionalLong findSingle() {
         if (!iterator.hasNext()) {
             return OptionalLong.empty();
@@ -1198,7 +1253,8 @@ public final class LongStream implements Closeable {
      * @return the new stream with the close handler
      * @since 1.1.8
      */
-    public LongStream onClose(final Runnable closeHandler) {
+    @NotNull
+    public LongStream onClose(@NotNull final Runnable closeHandler) {
         Objects.requireNonNull(closeHandler);
         final Params newParams;
         if (params == null) {

--- a/stream/src/main/java/com/annimon/stream/LongStream.java
+++ b/stream/src/main/java/com/annimon/stream/LongStream.java
@@ -619,7 +619,7 @@ public final class LongStream implements Closeable {
      * @return the new {@code LongStream}
      */
     @NotNull
-    public LongStream sorted(@NotNull Comparator<Long> comparator) {
+    public LongStream sorted(@Nullable Comparator<Long> comparator) {
         return boxed().sorted(comparator).mapToLong(UNBOX_FUNCTION);
     }
 

--- a/stream/src/main/java/com/annimon/stream/Objects.java
+++ b/stream/src/main/java/com/annimon/stream/Objects.java
@@ -5,6 +5,9 @@ import com.annimon.stream.function.Supplier;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Common operations with Object.
@@ -20,7 +23,8 @@ public final class Objects {
      * @param b  an object
      * @return {@code true} if objects are equals, {@code false} otherwise
      */
-    public static boolean equals(Object a, Object b) {
+    @Contract(pure = true)
+    public static boolean equals(@Nullable Object a, @Nullable Object b) {
         return (a == b) || (a != null && a.equals(b));
     }
 
@@ -34,7 +38,8 @@ public final class Objects {
      * @see Objects#equals(Object, Object)
      * @since 1.2.0
      */
-    public static boolean deepEquals(Object a, Object b) {
+    @Contract(pure = true)
+    public static boolean deepEquals(@Nullable Object a, @Nullable Object b) {
         return (a == b)
                 || (a != null && b != null)
                 && Arrays.deepEquals(new Object[] { a }, new Object[] { b });
@@ -46,7 +51,8 @@ public final class Objects {
      * @param o  an object
      * @return the hash code
      */
-    public static int hashCode(Object o) {
+    @Contract(pure = true)
+    public static int hashCode(@Nullable Object o) {
         return o != null ? o.hashCode() : 0;
     }
 
@@ -56,7 +62,8 @@ public final class Objects {
      * @param values  the values
      * @return the hash code
      */
-    public static int hash(Object... values) {
+    @Contract(pure = true)
+    public static int hash(@Nullable Object... values) {
         if (values == null) return 0;
 
         int result = 1;
@@ -72,7 +79,9 @@ public final class Objects {
      * @param nullDefault  a string to return if object is null
      * @return a result of calling {@code toString} on object or {@code nullDefault} if object is null.
      */
-    public static String toString(Object o, String nullDefault) {
+    @NotNull
+    @Contract("null, _ -> param2")
+    public static String toString(@Nullable Object o, @NotNull String nullDefault) {
         return (o != null) ? o.toString() : nullDefault;
     }
 
@@ -85,7 +94,8 @@ public final class Objects {
      * @param c  the comparator
      * @return comparing result
      */
-    public static <T> int compare(T a, T b, Comparator<? super T> c) {
+    @Contract(pure = true)
+    public static <T> int compare(@Nullable T a, @Nullable T b, @NotNull Comparator<? super T> c) {
         return (a == b) ? 0 : c.compare(a, b);
     }
 
@@ -97,6 +107,7 @@ public final class Objects {
      * @return comparing result
      * @since 1.1.6
      */
+    @Contract(pure = true)
     public static int compareInt(int x, int y) {
         return (x < y) ? -1 : ((x == y) ? 0 : 1);
     }
@@ -109,6 +120,7 @@ public final class Objects {
      * @return comparing result
      * @since 1.1.6
      */
+    @Contract(pure = true)
     public static int compareLong(long x, long y) {
         return (x < y) ? -1 : ((x == y) ? 0 : 1);
     }
@@ -122,7 +134,9 @@ public final class Objects {
      * @throws NullPointerException if object is {@code null}
      * @see #requireNonNull(java.lang.Object, java.lang.String)
      */
-    public static <T> T requireNonNull(T obj) {
+    @NotNull
+    @Contract(value = "null -> fail; !null -> param1", pure = true)
+    public static <T> T requireNonNull(@Nullable T obj) {
         if (obj == null)
             throw new NullPointerException();
         else return obj;
@@ -138,7 +152,9 @@ public final class Objects {
      * @throws NullPointerException if object is {@code null}
      * @see #requireNonNull(java.lang.Object)
      */
-    public static <T> T requireNonNull(T obj, String message) {
+    @NotNull
+    @Contract(value = "null, _ -> fail; !null, _ -> param1", pure = true)
+    public static <T> T requireNonNull(@Nullable T obj, @NotNull String message) {
         if (obj == null)
             throw new NullPointerException(message);
         else return obj;
@@ -156,7 +172,9 @@ public final class Objects {
      * @see #requireNonNull(java.lang.Object)
      * @since 1.2.0
      */
-    public static <T> T requireNonNull(T obj, Supplier<String> messageSupplier) {
+    @NotNull
+    @Contract("null, _ -> fail; !null, _ -> param1")
+    public static <T> T requireNonNull(@Nullable T obj, @NotNull Supplier<String> messageSupplier) {
         if (obj == null)
             throw new NullPointerException(messageSupplier.get());
         else return obj;
@@ -174,7 +192,9 @@ public final class Objects {
      *         the non-{@code null} second object otherwise.
      * @since 1.2.0
      */
-    public static <T> T requireNonNullElse(T obj, T defaultObj) {
+    @NotNull
+    @Contract(value = "!null, _ -> param1; null, !null -> param2; null, null -> fail", pure = true)
+    public static <T> T requireNonNullElse(@Nullable T obj, @NotNull T defaultObj) {
         return (obj != null) ? obj : requireNonNull(defaultObj, "defaultObj");
     }
 
@@ -190,7 +210,9 @@ public final class Objects {
      *         the non-{@code null} supplier's result otherwise
      * @since 1.2.0
      */
-    public static <T> T requireNonNullElseGet(T obj, Supplier<? extends T> supplier) {
+    @NotNull
+    @Contract("!null, _ -> param1; null, null -> fail")
+    public static <T> T requireNonNullElseGet(@Nullable T obj, @NotNull Supplier<? extends T> supplier) {
         if (obj != null) return obj;
         final T suppliedObj = requireNonNull(supplier, "supplier").get();
         return requireNonNull(suppliedObj, "supplier.get()");
@@ -205,7 +227,9 @@ public final class Objects {
      * @throws NullPointerException if collection or its elements are {@code null}
      * @since 1.2.0
      */
-    public static <T> Collection<T> requireNonNullElements(Collection<T> collection) {
+    @NotNull
+    @Contract("null -> fail; !null -> param1")
+    public static <T> Collection<T> requireNonNullElements(@NotNull Collection<T> collection) {
         requireNonNull(collection);
         for (T t : collection) {
             requireNonNull(t);
@@ -221,7 +245,8 @@ public final class Objects {
      * @see Predicate
      * @since 1.2.0
      */
-    public static boolean isNull(Object obj) {
+    @Contract(value = "null -> true; !null -> false", pure = true)
+    public static boolean isNull(@Nullable Object obj) {
         return obj == null;
     }
 
@@ -234,7 +259,8 @@ public final class Objects {
      * @see Predicate.Util#notNull()
      * @since 1.2.0
      */
-    public static boolean nonNull(Object obj) {
+    @Contract(value = "null -> false; !null -> true", pure = true)
+    public static boolean nonNull(@Nullable Object obj) {
         return obj != null;
     }
 }

--- a/stream/src/main/java/com/annimon/stream/Optional.java
+++ b/stream/src/main/java/com/annimon/stream/Optional.java
@@ -10,6 +10,9 @@ import com.annimon.stream.function.ToLongFunction;
 import com.annimon.stream.function.ToBooleanFunction;
 
 import java.util.NoSuchElementException;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * A container object which may or may not contain a non-null value.
@@ -29,7 +32,9 @@ public class Optional<T> {
      * @throws NullPointerException if value is null
      * @see #ofNullable(java.lang.Object)
      */
-    public static <T> Optional<T> of(T value) {
+    @NotNull
+    @Contract("_ -> new")
+    public static <T> Optional<T> of(@NotNull T value) {
         return new Optional<T>(value);
     }
 
@@ -41,7 +46,8 @@ public class Optional<T> {
      * @return an {@code Optional}
      * @see #of(java.lang.Object)
      */
-    public static <T> Optional<T> ofNullable(T value) {
+    @NotNull
+    public static <T> Optional<T> ofNullable(@Nullable T value) {
         return value == null ? Optional.<T>empty() : of(value);
     }
 
@@ -51,11 +57,14 @@ public class Optional<T> {
      * @param <T> the type of value
      * @return an {@code Optional}
      */
+    @NotNull
+    @Contract(pure = true)
     @SuppressWarnings("unchecked")
     public static <T> Optional<T> empty() {
         return (Optional<T>) EMPTY;
     }
 
+    @Nullable
     private final T value;
 
     private Optional() {
@@ -75,6 +84,7 @@ public class Optional<T> {
      * @throws NoSuchElementException if value is not present
      * @see #orElseThrow()
      */
+    @NotNull
     public T get() {
         return orElseThrow();
     }
@@ -103,7 +113,7 @@ public class Optional<T> {
      *
      * @param consumer  the consumer function
      */
-    public void ifPresent(Consumer<? super T> consumer) {
+    public void ifPresent(@NotNull Consumer<? super T> consumer) {
         if (value != null)
             consumer.accept(value);
     }
@@ -117,7 +127,7 @@ public class Optional<T> {
      * @throws NullPointerException if a value is present and the given consumer function is null,
      *         or no value is present and the given empty-based action is null.
      */
-    public void ifPresentOrElse(Consumer<? super T> consumer, Runnable emptyAction) {
+    public void ifPresentOrElse(@NotNull Consumer<? super T> consumer, @NotNull Runnable emptyAction) {
         if (value != null) {
             consumer.accept(value);
         } else {
@@ -134,7 +144,8 @@ public class Optional<T> {
      * @see #ifPresent(com.annimon.stream.function.Consumer)
      * @since 1.1.2
      */
-    public Optional<T> executeIfPresent(Consumer<? super T> consumer) {
+    @NotNull
+    public Optional<T> executeIfPresent(@NotNull Consumer<? super T> consumer) {
         ifPresent(consumer);
         return this;
     }
@@ -146,7 +157,8 @@ public class Optional<T> {
      * @return this {@code Optional}
      * @since 1.1.2
      */
-    public Optional<T> executeIfAbsent(Runnable action) {
+    @NotNull
+    public Optional<T> executeIfAbsent(@NotNull Runnable action) {
         if (value == null)
             action.run();
         return this;
@@ -161,7 +173,8 @@ public class Optional<T> {
      * @throws NullPointerException if {@code function} is null
      * @since 1.1.9
      */
-    public <R> R custom(Function<Optional<T>, R> function) {
+    @Nullable
+    public <R> R custom(@NotNull Function<Optional<T>, R> function) {
         Objects.requireNonNull(function);
         return function.apply(this);
     }
@@ -173,7 +186,8 @@ public class Optional<T> {
      * @return this {@code Optional} if the value is present and matches predicate,
      *              otherwise an empty {@code Optional}
      */
-    public Optional<T> filter(Predicate<? super T> predicate) {
+    @NotNull
+    public Optional<T> filter(@NotNull Predicate<? super T> predicate) {
         if (!isPresent()) return this;
         return predicate.test(value) ? this : Optional.<T>empty();
     }
@@ -186,7 +200,8 @@ public class Optional<T> {
      *              otherwise an empty {@code Optional}
      * @since 1.1.9
      */
-    public Optional<T> filterNot(Predicate<? super T> predicate) {
+    @NotNull
+    public Optional<T> filterNot(@NotNull Predicate<? super T> predicate) {
         return filter(Predicate.Util.negate(predicate));
     }
 
@@ -200,7 +215,8 @@ public class Optional<T> {
      * @throws NullPointerException if value is present and
      *         {@code mapper} is {@code null}
      */
-    public <U> Optional<U> map(Function<? super T, ? extends U> mapper) {
+    @NotNull
+    public <U> Optional<U> map(@NotNull Function<? super T, ? extends U> mapper) {
         if (!isPresent()) return empty();
         return Optional.ofNullable(mapper.apply(value));
     }
@@ -215,7 +231,8 @@ public class Optional<T> {
      *         {@code mapper} is {@code null}
      * @since 1.1.3
      */
-    public OptionalInt mapToInt(ToIntFunction<? super T> mapper) {
+    @NotNull
+    public OptionalInt mapToInt(@NotNull ToIntFunction<? super T> mapper) {
         if (!isPresent()) return OptionalInt.empty();
         return OptionalInt.of(mapper.applyAsInt(value));
     }
@@ -230,7 +247,8 @@ public class Optional<T> {
      *         {@code mapper} is {@code null}
      * @since 1.1.4
      */
-    public OptionalLong mapToLong(ToLongFunction<? super T> mapper) {
+    @NotNull
+    public OptionalLong mapToLong(@NotNull ToLongFunction<? super T> mapper) {
         if (!isPresent()) return OptionalLong.empty();
         return OptionalLong.of(mapper.applyAsLong(value));
     }
@@ -245,7 +263,8 @@ public class Optional<T> {
      *         {@code mapper} is {@code null}
      * @since 1.1.4
      */
-    public OptionalDouble mapToDouble(ToDoubleFunction<? super T> mapper) {
+    @NotNull
+    public OptionalDouble mapToDouble(@NotNull ToDoubleFunction<? super T> mapper) {
         if (!isPresent()) return OptionalDouble.empty();
         return OptionalDouble.of(mapper.applyAsDouble(value));
     }
@@ -259,7 +278,8 @@ public class Optional<T> {
      * @throws NullPointerException if value is present and
      *         {@code mapper} is {@code null}
      */
-    public OptionalBoolean mapToBoolean(ToBooleanFunction<? super T> mapper) {
+    @NotNull
+    public OptionalBoolean mapToBoolean(@NotNull ToBooleanFunction<? super T> mapper) {
         if (!isPresent()) return OptionalBoolean.empty();
         return OptionalBoolean.of(mapper.applyAsBoolean(value));
     }
@@ -271,7 +291,8 @@ public class Optional<T> {
      * @param mapper  mapping function
      * @return an {@code Optional} with transformed value if present, otherwise an empty {@code Optional}
      */
-    public <U> Optional<U> flatMap(Function<? super T, Optional<U>> mapper) {
+    @NotNull
+    public <U> Optional<U> flatMap(@NotNull Function<? super T, Optional<U>> mapper) {
         if (!isPresent()) return empty();
         return Objects.requireNonNull(mapper.apply(value));
     }
@@ -281,6 +302,7 @@ public class Optional<T> {
      *
      * @return the optional value as a {@code Stream}
      */
+    @NotNull
     @SuppressWarnings("unchecked")
     public Stream<T> stream() {
         if (!isPresent()) return Stream.empty();
@@ -294,8 +316,9 @@ public class Optional<T> {
      * @param clazz a class which instance should be selected
      * @return an {@code Optional} with value of type class if present, otherwise an empty {@code Optional}
      */
+    @NotNull
     @SuppressWarnings("unchecked")
-    public <R> Optional<R> select(Class<R> clazz) {
+    public <R> Optional<R> select(@NotNull Class<R> clazz) {
         Objects.requireNonNull(clazz);
         if (!isPresent()) return empty();
         return (Optional<R>) Optional.ofNullable(clazz.isInstance(value) ? value : null);
@@ -311,7 +334,8 @@ public class Optional<T> {
      * @throws NullPointerException if value is not present and
      *         {@code supplier} or value produced by it is {@code null}
      */
-    public Optional<T> or(Supplier<Optional<T>> supplier) {
+    @NotNull
+    public Optional<T> or(@NotNull Supplier<Optional<T>> supplier) {
         if (isPresent()) return this;
         Objects.requireNonNull(supplier);
         return Objects.requireNonNull(supplier.get());
@@ -323,7 +347,8 @@ public class Optional<T> {
      * @param other  the value to be returned if inner value is not present
      * @return inner value if present, otherwise {@code other}
      */
-    public T orElse(T other) {
+    @Nullable
+    public T orElse(@Nullable T other) {
         return value != null ? value : other;
     }
 
@@ -333,7 +358,8 @@ public class Optional<T> {
      * @param other  supplier function that produces value if inner value is not present
      * @return inner value if present, otherwise value produced by supplier function
      */
-    public T orElseGet(Supplier<? extends T> other) {
+    @Nullable
+    public T orElseGet(@NotNull Supplier<? extends T> other) {
         return value != null ? value : other.get();
     }
 
@@ -344,6 +370,7 @@ public class Optional<T> {
      * @throws NoSuchElementException if inner value is not present
      * @since 1.2.0
      */
+    @NotNull
     public T orElseThrow() {
         if (value == null) {
             throw new NoSuchElementException("No value present");
@@ -359,7 +386,8 @@ public class Optional<T> {
      * @return inner value if present
      * @throws X if inner value is not present
      */
-    public <X extends Throwable> T orElseThrow(Supplier<? extends X> exc) throws X {
+    @NotNull
+    public <X extends Throwable> T orElseThrow(@NotNull Supplier<? extends X> exc) throws X {
         if (value != null) return value;
         else throw exc.get();
     }
@@ -383,6 +411,7 @@ public class Optional<T> {
         return Objects.hashCode(value);
     }
 
+    @NotNull
     @Override
     public String toString() {
         return value != null

--- a/stream/src/main/java/com/annimon/stream/OptionalBoolean.java
+++ b/stream/src/main/java/com/annimon/stream/OptionalBoolean.java
@@ -7,6 +7,8 @@ import com.annimon.stream.function.BooleanSupplier;
 import com.annimon.stream.function.Function;
 import com.annimon.stream.function.Supplier;
 import java.util.NoSuchElementException;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * A container object which may or may not contain a {@code boolean} value.
@@ -26,6 +28,7 @@ public final class OptionalBoolean {
      *
      * @return an empty {@code OptionalBoolean}
      */
+    @NotNull
     public static OptionalBoolean empty() {
         return EMPTY;
     }
@@ -36,6 +39,7 @@ public final class OptionalBoolean {
      * @param value  the value to be present
      * @return an {@code OptionalBoolean} with the value present
      */
+    @NotNull
     public static OptionalBoolean of(boolean value) {
         return value ? TRUE : FALSE;
     }
@@ -47,7 +51,8 @@ public final class OptionalBoolean {
      * @return an {@code OptionalBoolean}
      * @since 1.2.1
      */
-    public static OptionalBoolean ofNullable(Boolean value) {
+    @NotNull
+    public static OptionalBoolean ofNullable(@Nullable Boolean value) {
         return value == null ? EMPTY : of(value);
     }
 
@@ -103,7 +108,7 @@ public final class OptionalBoolean {
      * @param consumer  the consumer function to be executed if a value is present
      * @throws NullPointerException if value is present and {@code consumer} is null
      */
-    public void ifPresent(BooleanConsumer consumer) {
+    public void ifPresent(@NotNull BooleanConsumer consumer) {
         if (isPresent) {
             consumer.accept(value);
         }
@@ -118,7 +123,7 @@ public final class OptionalBoolean {
      * @throws NullPointerException if a value is present and the given consumer function is null,
      *         or no value is present and the given empty-based action is null.
      */
-    public void ifPresentOrElse(BooleanConsumer consumer, Runnable emptyAction) {
+    public void ifPresentOrElse(@NotNull BooleanConsumer consumer, @NotNull Runnable emptyAction) {
         if (isPresent) {
             consumer.accept(value);
         } else {
@@ -134,7 +139,8 @@ public final class OptionalBoolean {
      * @return this {@code OptionalBoolean}
      * @see #ifPresent(BooleanConsumer)
      */
-    public OptionalBoolean executeIfPresent(BooleanConsumer consumer) {
+    @NotNull
+    public OptionalBoolean executeIfPresent(@NotNull BooleanConsumer consumer) {
         ifPresent(consumer);
         return this;
     }
@@ -145,7 +151,8 @@ public final class OptionalBoolean {
      * @param action  action that invokes if value absent
      * @return this {@code OptionalBoolean}
      */
-    public OptionalBoolean executeIfAbsent(Runnable action) {
+    @NotNull
+    public OptionalBoolean executeIfAbsent(@NotNull Runnable action) {
         if (!isPresent()) {
             action.run();
         }
@@ -161,7 +168,8 @@ public final class OptionalBoolean {
      * @throws NullPointerException if {@code function} is null
      * @since 1.1.9
      */
-    public <R> R custom(Function<OptionalBoolean, R> function) {
+    @Nullable
+    public <R> R custom(@NotNull Function<OptionalBoolean, R> function) {
         Objects.requireNonNull(function);
         return function.apply(this);
     }
@@ -173,7 +181,8 @@ public final class OptionalBoolean {
      * @return this {@code OptionalBoolean} if the value is present and matches predicate,
      *         otherwise an empty {@code OptionalBoolean}
      */
-    public OptionalBoolean filter(BooleanPredicate predicate) {
+    @NotNull
+    public OptionalBoolean filter(@NotNull BooleanPredicate predicate) {
         if (!isPresent()) return this;
         return predicate.test(value) ? this : OptionalBoolean.empty();
     }
@@ -186,7 +195,8 @@ public final class OptionalBoolean {
      *              otherwise an empty {@code OptionalBoolean}
      * @since 1.1.9
      */
-    public OptionalBoolean filterNot(BooleanPredicate predicate) {
+    @NotNull
+    public OptionalBoolean filterNot(@NotNull BooleanPredicate predicate) {
         return filter(BooleanPredicate.Util.negate(predicate));
     }
 
@@ -199,7 +209,8 @@ public final class OptionalBoolean {
      * @throws NullPointerException if value is present and
      *         {@code mapper} is {@code null}
      */
-    public OptionalBoolean map(BooleanPredicate mapper) {
+    @NotNull
+    public OptionalBoolean map(@NotNull BooleanPredicate mapper) {
         if (!isPresent()) {
             return empty();
         }
@@ -217,7 +228,8 @@ public final class OptionalBoolean {
      * @throws NullPointerException if value is present and
      *         {@code mapper} is {@code null}
      */
-    public <U> Optional<U> mapToObj(BooleanFunction<U> mapper) {
+    @NotNull
+    public <U> Optional<U> mapToObj(@NotNull BooleanFunction<U> mapper) {
         if (!isPresent()) {
             return Optional.empty();
         }
@@ -235,7 +247,8 @@ public final class OptionalBoolean {
      * @throws NullPointerException if value is not present and
      *         {@code supplier} or value produced by it is {@code null}
      */
-    public OptionalBoolean or(Supplier<OptionalBoolean> supplier) {
+    @NotNull
+    public OptionalBoolean or(@NotNull Supplier<OptionalBoolean> supplier) {
         if (isPresent()) return this;
         Objects.requireNonNull(supplier);
         return Objects.requireNonNull(supplier.get());
@@ -258,7 +271,7 @@ public final class OptionalBoolean {
      * @return the value if present otherwise the result of {@code other.getAsBoolean()}
      * @throws NullPointerException if value is not present and {@code other} is null
      */
-    public boolean orElseGet(BooleanSupplier other) {
+    public boolean orElseGet(@NotNull BooleanSupplier other) {
         return isPresent ? value : other.getAsBoolean();
     }
 
@@ -284,7 +297,7 @@ public final class OptionalBoolean {
      * @return inner value if present
      * @throws X if inner value is not present
      */
-    public <X extends Throwable> boolean orElseThrow(Supplier<X> exceptionSupplier) throws X {
+    public <X extends Throwable> boolean orElseThrow(@NotNull Supplier<X> exceptionSupplier) throws X {
         if (isPresent) {
             return value;
         } else {
@@ -310,6 +323,7 @@ public final class OptionalBoolean {
         return isPresent ? (value ? 1231 : 1237) : 0;
     }
 
+    @NotNull
     @Override
     public String toString() {
         return isPresent

--- a/stream/src/main/java/com/annimon/stream/OptionalDouble.java
+++ b/stream/src/main/java/com/annimon/stream/OptionalDouble.java
@@ -10,6 +10,8 @@ import com.annimon.stream.function.DoubleUnaryOperator;
 import com.annimon.stream.function.Function;
 import com.annimon.stream.function.Supplier;
 import java.util.NoSuchElementException;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * A container object which may or may not contain a {@code double} value.
@@ -27,6 +29,7 @@ public final class OptionalDouble {
      *
      * @return an empty {@code OptionalDouble}
      */
+    @NotNull
     public static OptionalDouble empty() {
         return EMPTY;
     }
@@ -37,6 +40,7 @@ public final class OptionalDouble {
      * @param value  the value to be present
      * @return an {@code OptionalDouble} with the value present
      */
+    @NotNull
     public static OptionalDouble of(double value) {
         return new OptionalDouble(value);
     }
@@ -48,7 +52,8 @@ public final class OptionalDouble {
      * @return an {@code OptionalDouble}
      * @since 1.2.1
      */
-    public static OptionalDouble ofNullable(Double value) {
+    @NotNull
+    public static OptionalDouble ofNullable(@Nullable Double value) {
         return value == null ? EMPTY : new OptionalDouble(value);
     }
 
@@ -104,7 +109,7 @@ public final class OptionalDouble {
      * @param consumer  the consumer function to be executed if a value is present
      * @throws NullPointerException if value is present and {@code consumer} is null
      */
-    public void ifPresent(DoubleConsumer consumer) {
+    public void ifPresent(@NotNull DoubleConsumer consumer) {
         if (isPresent) {
             consumer.accept(value);
         }
@@ -119,7 +124,7 @@ public final class OptionalDouble {
      * @throws NullPointerException if a value is present and the given consumer function is null,
      *         or no value is present and the given empty-based action is null.
      */
-    public void ifPresentOrElse(DoubleConsumer consumer, Runnable emptyAction) {
+    public void ifPresentOrElse(@NotNull DoubleConsumer consumer, @NotNull Runnable emptyAction) {
         if (isPresent) {
             consumer.accept(value);
         } else {
@@ -135,7 +140,8 @@ public final class OptionalDouble {
      * @return this {@code OptionalDouble}
      * @see #ifPresent(com.annimon.stream.function.DoubleConsumer)
      */
-    public OptionalDouble executeIfPresent(DoubleConsumer consumer) {
+    @NotNull
+    public OptionalDouble executeIfPresent(@NotNull DoubleConsumer consumer) {
         ifPresent(consumer);
         return this;
     }
@@ -146,7 +152,8 @@ public final class OptionalDouble {
      * @param action  action that invokes if value absent
      * @return this {@code OptionalDouble}
      */
-    public OptionalDouble executeIfAbsent(Runnable action) {
+    @NotNull
+    public OptionalDouble executeIfAbsent(@NotNull Runnable action) {
         if (!isPresent()) {
             action.run();
         }
@@ -162,7 +169,8 @@ public final class OptionalDouble {
      * @throws NullPointerException if {@code function} is null
      * @since 1.1.9
      */
-    public <R> R custom(Function<OptionalDouble, R> function) {
+    @Nullable
+    public <R> R custom(@NotNull Function<OptionalDouble, R> function) {
         Objects.requireNonNull(function);
         return function.apply(this);
     }
@@ -174,7 +182,8 @@ public final class OptionalDouble {
      * @return this {@code OptionalDouble} if the value is present and matches predicate,
      *         otherwise an empty {@code OptionalDouble}
      */
-    public OptionalDouble filter(DoublePredicate predicate) {
+    @NotNull
+    public OptionalDouble filter(@NotNull DoublePredicate predicate) {
         if (!isPresent()) return this;
         return predicate.test(value) ? this : OptionalDouble.empty();
     }
@@ -187,7 +196,8 @@ public final class OptionalDouble {
      *              otherwise an empty {@code OptionalDouble}
      * @since 1.1.9
      */
-    public OptionalDouble filterNot(DoublePredicate predicate) {
+    @NotNull
+    public OptionalDouble filterNot(@NotNull DoublePredicate predicate) {
         return filter(DoublePredicate.Util.negate(predicate));
     }
 
@@ -200,7 +210,8 @@ public final class OptionalDouble {
      * @throws NullPointerException if value is present and
      *         {@code mapper} is {@code null}
      */
-    public OptionalDouble map(DoubleUnaryOperator mapper) {
+    @NotNull
+    public OptionalDouble map(@NotNull DoubleUnaryOperator mapper) {
         if (!isPresent()) {
             return empty();
         }
@@ -218,7 +229,8 @@ public final class OptionalDouble {
      * @throws NullPointerException if value is present and
      *         {@code mapper} is {@code null}
      */
-    public <U> Optional<U> mapToObj(DoubleFunction<U> mapper) {
+    @NotNull
+    public <U> Optional<U> mapToObj(@NotNull DoubleFunction<U> mapper) {
         if (!isPresent()) {
             return Optional.empty();
         }
@@ -235,7 +247,8 @@ public final class OptionalDouble {
      * @throws NullPointerException if value is present and
      *         {@code mapper} is {@code null}
      */
-    public OptionalInt mapToInt(DoubleToIntFunction mapper) {
+    @NotNull
+    public OptionalInt mapToInt(@NotNull DoubleToIntFunction mapper) {
         if (!isPresent()) {
             return OptionalInt.empty();
         }
@@ -252,7 +265,8 @@ public final class OptionalDouble {
      * @throws NullPointerException if value is present and
      *         {@code mapper} is {@code null}
      */
-    public OptionalLong mapToLong(DoubleToLongFunction mapper) {
+    @NotNull
+    public OptionalLong mapToLong(@NotNull DoubleToLongFunction mapper) {
         if (!isPresent()) {
             return OptionalLong.empty();
         }
@@ -266,6 +280,7 @@ public final class OptionalDouble {
      *
      * @return the optional value as an {@code DoubleStream}
      */
+    @NotNull
     public DoubleStream stream() {
         if (!isPresent()) {
             return DoubleStream.empty();
@@ -283,7 +298,8 @@ public final class OptionalDouble {
      * @throws NullPointerException if value is not present and
      *         {@code supplier} or value produced by it is {@code null}
      */
-    public OptionalDouble or(Supplier<OptionalDouble> supplier) {
+    @NotNull
+    public OptionalDouble or(@NotNull Supplier<OptionalDouble> supplier) {
         if (isPresent()) return this;
         Objects.requireNonNull(supplier);
         return Objects.requireNonNull(supplier.get());
@@ -306,7 +322,7 @@ public final class OptionalDouble {
      * @return the value if present otherwise the result of {@code other.getAsDouble()}
      * @throws NullPointerException if value is not present and {@code other} is null
      */
-    public double orElseGet(DoubleSupplier other) {
+    public double orElseGet(@NotNull DoubleSupplier other) {
         return isPresent ? value : other.getAsDouble();
     }
 
@@ -332,7 +348,7 @@ public final class OptionalDouble {
      * @return inner value if present
      * @throws X if inner value is not present
      */
-    public <X extends Throwable> double orElseThrow(Supplier<X> exceptionSupplier) throws X {
+    public <X extends Throwable> double orElseThrow(@NotNull Supplier<X> exceptionSupplier) throws X {
         if (isPresent) {
             return value;
         } else {
@@ -358,6 +374,7 @@ public final class OptionalDouble {
         return isPresent ? Objects.hashCode(value) : 0;
     }
 
+    @NotNull
     @Override
     public String toString() {
         return isPresent

--- a/stream/src/main/java/com/annimon/stream/OptionalInt.java
+++ b/stream/src/main/java/com/annimon/stream/OptionalInt.java
@@ -10,6 +10,8 @@ import com.annimon.stream.function.IntToLongFunction;
 import com.annimon.stream.function.IntUnaryOperator;
 import com.annimon.stream.function.Supplier;
 import java.util.NoSuchElementException;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * A container object which may or may not contain a {@code int} value.
@@ -43,6 +45,7 @@ public final class OptionalInt {
      *
      * @return an empty {@code OptionalInt}
      */
+    @NotNull
     public static OptionalInt empty() {
         return EMPTY;
     }
@@ -63,6 +66,7 @@ public final class OptionalInt {
      * @param value the value to be present
      * @return an {@code OptionalInt} with the value present
      */
+    @NotNull
     public static OptionalInt of(int value) {
         return new OptionalInt(value);
     }
@@ -74,7 +78,8 @@ public final class OptionalInt {
      * @return an {@code OptionalInt}
      * @since 1.2.1
      */
-    public static OptionalInt ofNullable(Integer value) {
+    @NotNull
+    public static OptionalInt ofNullable(@Nullable Integer value) {
         return value == null ? EMPTY : new OptionalInt(value);
     }
 
@@ -119,7 +124,7 @@ public final class OptionalInt {
      * @throws NullPointerException if value is present and {@code consumer} is
      *         null
      */
-    public void ifPresent(IntConsumer consumer) {
+    public void ifPresent(@NotNull IntConsumer consumer) {
         if (isPresent)
             consumer.accept(value);
     }
@@ -134,7 +139,7 @@ public final class OptionalInt {
      *         or no value is present and the given empty-based action is null.
      * @since 1.1.4
      */
-    public void ifPresentOrElse(IntConsumer consumer, Runnable emptyAction) {
+    public void ifPresentOrElse(@NotNull IntConsumer consumer, @NotNull Runnable emptyAction) {
         if (isPresent) {
             consumer.accept(value);
         } else {
@@ -151,7 +156,8 @@ public final class OptionalInt {
      * @see #ifPresent(com.annimon.stream.function.IntConsumer)
      * @since 1.1.2
      */
-    public OptionalInt executeIfPresent(IntConsumer consumer) {
+    @NotNull
+    public OptionalInt executeIfPresent(@NotNull IntConsumer consumer) {
         ifPresent(consumer);
         return this;
     }
@@ -163,7 +169,8 @@ public final class OptionalInt {
      * @return this {@code OptionalInt}
      * @since 1.1.2
      */
-    public OptionalInt executeIfAbsent(Runnable action) {
+    @NotNull
+    public OptionalInt executeIfAbsent(@NotNull Runnable action) {
         if (!isPresent())
             action.run();
         return this;
@@ -178,7 +185,8 @@ public final class OptionalInt {
      * @throws NullPointerException if {@code function} is null
      * @since 1.1.9
      */
-    public <R> R custom(Function<OptionalInt, R> function) {
+    @Nullable
+    public <R> R custom(@NotNull Function<OptionalInt, R> function) {
         Objects.requireNonNull(function);
         return function.apply(this);
     }
@@ -191,7 +199,8 @@ public final class OptionalInt {
      *         otherwise an empty {@code OptionalInt}
      * @since 1.1.4
      */
-    public OptionalInt filter(IntPredicate predicate) {
+    @NotNull
+    public OptionalInt filter(@NotNull IntPredicate predicate) {
         if (!isPresent()) return this;
         return predicate.test(value) ? this : OptionalInt.empty();
     }
@@ -204,7 +213,8 @@ public final class OptionalInt {
      *              otherwise an empty {@code OptionalInt}
      * @since 1.1.9
      */
-    public OptionalInt filterNot(IntPredicate predicate) {
+    @NotNull
+    public OptionalInt filterNot(@NotNull IntPredicate predicate) {
         return filter(IntPredicate.Util.negate(predicate));
     }
 
@@ -218,7 +228,8 @@ public final class OptionalInt {
      *         {@code mapper} is {@code null}
      * @since 1.1.3
      */
-    public OptionalInt map(IntUnaryOperator mapper) {
+    @NotNull
+    public OptionalInt map(@NotNull IntUnaryOperator mapper) {
         if (!isPresent()) return empty();
         return OptionalInt.of(mapper.applyAsInt(value));
     }
@@ -234,7 +245,8 @@ public final class OptionalInt {
      *         {@code mapper} is {@code null}
      * @since 1.1.3
      */
-    public <U> Optional<U> mapToObj(IntFunction<U> mapper) {
+    @NotNull
+    public <U> Optional<U> mapToObj(@NotNull IntFunction<U> mapper) {
         if (!isPresent()) return Optional.empty();
         return Optional.ofNullable(mapper.apply(value));
     }
@@ -249,7 +261,8 @@ public final class OptionalInt {
      *         {@code mapper} is {@code null}
      * @since 1.1.4
      */
-    public OptionalLong mapToLong(IntToLongFunction mapper) {
+    @NotNull
+    public OptionalLong mapToLong(@NotNull IntToLongFunction mapper) {
         if (!isPresent()) return OptionalLong.empty();
         return OptionalLong.of(mapper.applyAsLong(value));
     }
@@ -264,7 +277,8 @@ public final class OptionalInt {
      *         {@code mapper} is {@code null}
      * @since 1.1.4
      */
-    public OptionalDouble mapToDouble(IntToDoubleFunction mapper) {
+    @NotNull
+    public OptionalDouble mapToDouble(@NotNull IntToDoubleFunction mapper) {
         if (!isPresent()) return OptionalDouble.empty();
         return OptionalDouble.of(mapper.applyAsDouble(value));
     }
@@ -274,6 +288,7 @@ public final class OptionalInt {
      *
      * @return the optional value as an {@code IntStream}
      */
+    @NotNull
     public IntStream stream() {
         if (!isPresent()) return IntStream.empty();
         return IntStream.of(value);
@@ -289,7 +304,8 @@ public final class OptionalInt {
      * @throws NullPointerException if value is not present and
      *         {@code supplier} or value produced by it is {@code null}
      */
-    public OptionalInt or(Supplier<OptionalInt> supplier) {
+    @NotNull
+    public OptionalInt or(@NotNull Supplier<OptionalInt> supplier) {
         if (isPresent()) return this;
         Objects.requireNonNull(supplier);
         return Objects.requireNonNull(supplier.get());
@@ -315,7 +331,7 @@ public final class OptionalInt {
      * @throws NullPointerException if value is not present and {@code other} is
      *         null
      */
-    public int orElseGet(IntSupplier other) {
+    public int orElseGet(@NotNull IntSupplier other) {
         return isPresent ? value : other.getAsInt();
     }
 
@@ -341,7 +357,7 @@ public final class OptionalInt {
      * @return inner value if present
      * @throws X if inner value is not present
      */
-    public <X extends Throwable> int orElseThrow(Supplier<X> exceptionSupplier) throws X {
+    public <X extends Throwable> int orElseThrow(@NotNull Supplier<X> exceptionSupplier) throws X {
         if (isPresent) {
             return value;
         } else {
@@ -395,6 +411,7 @@ public final class OptionalInt {
      *
      * @return the string representation of this instance
      */
+    @NotNull
     @Override
     public String toString() {
         return isPresent

--- a/stream/src/main/java/com/annimon/stream/OptionalLong.java
+++ b/stream/src/main/java/com/annimon/stream/OptionalLong.java
@@ -9,6 +9,8 @@ import com.annimon.stream.function.LongToIntFunction;
 import com.annimon.stream.function.LongUnaryOperator;
 import com.annimon.stream.function.Supplier;
 import java.util.NoSuchElementException;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * A container object which may or may not contain a {@code long} value.
@@ -26,6 +28,7 @@ public final class OptionalLong {
      *
      * @return an empty {@code OptionalLong}
      */
+    @NotNull
     public static OptionalLong empty() {
         return EMPTY;
     }
@@ -36,6 +39,7 @@ public final class OptionalLong {
      * @param value  the value to be present
      * @return an {@code OptionalLong} with the value present
      */
+    @NotNull
     public static OptionalLong of(long value) {
         return new OptionalLong(value);
     }
@@ -47,7 +51,8 @@ public final class OptionalLong {
      * @return an {@code OptionalLong}
      * @since 1.2.1
      */
-    public static OptionalLong ofNullable(Long value) {
+    @NotNull
+    public static OptionalLong ofNullable(@Nullable Long value) {
         return value == null ? EMPTY : new OptionalLong(value);
     }
 
@@ -103,7 +108,7 @@ public final class OptionalLong {
      * @param consumer  the consumer function to be executed if a value is present
      * @throws NullPointerException if value is present and {@code consumer} is null
      */
-    public void ifPresent(LongConsumer consumer) {
+    public void ifPresent(@NotNull LongConsumer consumer) {
         if (isPresent) {
             consumer.accept(value);
         }
@@ -118,7 +123,7 @@ public final class OptionalLong {
      * @throws NullPointerException if a value is present and the given consumer function is null,
      *         or no value is present and the given empty-based action is null.
      */
-    public void ifPresentOrElse(LongConsumer consumer, Runnable emptyAction) {
+    public void ifPresentOrElse(@NotNull LongConsumer consumer, @NotNull Runnable emptyAction) {
         if (isPresent) {
             consumer.accept(value);
         } else {
@@ -134,7 +139,8 @@ public final class OptionalLong {
      * @return this {@code OptionalLong}
      * @see #ifPresent(com.annimon.stream.function.LongConsumer)
      */
-    public OptionalLong executeIfPresent(LongConsumer consumer) {
+    @NotNull
+    public OptionalLong executeIfPresent(@NotNull LongConsumer consumer) {
         ifPresent(consumer);
         return this;
     }
@@ -145,7 +151,8 @@ public final class OptionalLong {
      * @param action  action that invokes if value absent
      * @return this {@code OptionalLong}
      */
-    public OptionalLong executeIfAbsent(Runnable action) {
+    @NotNull
+    public OptionalLong executeIfAbsent(@NotNull Runnable action) {
         if (!isPresent()) {
             action.run();
         }
@@ -161,7 +168,8 @@ public final class OptionalLong {
      * @throws NullPointerException if {@code function} is null
      * @since 1.1.9
      */
-    public <R> R custom(Function<OptionalLong, R> function) {
+    @Nullable
+    public <R> R custom(@NotNull Function<OptionalLong, R> function) {
         Objects.requireNonNull(function);
         return function.apply(this);
     }
@@ -173,7 +181,8 @@ public final class OptionalLong {
      * @return this {@code OptionalLong} if the value is present and matches predicate,
      *         otherwise an empty {@code OptionalLong}
      */
-    public OptionalLong filter(LongPredicate predicate) {
+    @NotNull
+    public OptionalLong filter(@NotNull LongPredicate predicate) {
         if (!isPresent()) return this;
         return predicate.test(value) ? this : OptionalLong.empty();
     }
@@ -186,7 +195,8 @@ public final class OptionalLong {
      *              otherwise an empty {@code OptionalLong}
      * @since 1.1.9
      */
-    public OptionalLong filterNot(LongPredicate predicate) {
+    @NotNull
+    public OptionalLong filterNot(@NotNull LongPredicate predicate) {
         return filter(LongPredicate.Util.negate(predicate));
     }
 
@@ -199,7 +209,8 @@ public final class OptionalLong {
      * @throws NullPointerException if value is present and
      *         {@code mapper} is {@code null}
      */
-    public OptionalLong map(LongUnaryOperator mapper) {
+    @NotNull
+    public OptionalLong map(@NotNull LongUnaryOperator mapper) {
         if (!isPresent()) {
             return empty();
         }
@@ -217,7 +228,8 @@ public final class OptionalLong {
      * @throws NullPointerException if value is present and
      *         {@code mapper} is {@code null}
      */
-    public <U> Optional<U> mapToObj(LongFunction<U> mapper) {
+    @NotNull
+    public <U> Optional<U> mapToObj(@NotNull LongFunction<U> mapper) {
         if (!isPresent()) {
             return Optional.empty();
         }
@@ -234,7 +246,8 @@ public final class OptionalLong {
      * @throws NullPointerException if value is present and
      *         {@code mapper} is {@code null}
      */
-    public OptionalInt mapToInt(LongToIntFunction mapper) {
+    @NotNull
+    public OptionalInt mapToInt(@NotNull LongToIntFunction mapper) {
         if (!isPresent()) {
             return OptionalInt.empty();
         }
@@ -248,6 +261,7 @@ public final class OptionalLong {
      *
      * @return the optional value as an {@code LongStream}
      */
+    @NotNull
     public LongStream stream() {
         if (!isPresent()) {
             return LongStream.empty();
@@ -265,7 +279,8 @@ public final class OptionalLong {
      * @throws NullPointerException if value is not present and
      *         {@code supplier} or value produced by it is {@code null}
      */
-    public OptionalLong or(Supplier<OptionalLong> supplier) {
+    @NotNull
+    public OptionalLong or(@NotNull Supplier<OptionalLong> supplier) {
         if (isPresent()) return this;
         Objects.requireNonNull(supplier);
         return Objects.requireNonNull(supplier.get());
@@ -288,7 +303,7 @@ public final class OptionalLong {
      * @return the value if present otherwise the result of {@code other.getAsLong()}
      * @throws NullPointerException if value is not present and {@code other} is null
      */
-    public long orElseGet(LongSupplier other) {
+    public long orElseGet(@NotNull LongSupplier other) {
         return isPresent ? value : other.getAsLong();
     }
 
@@ -314,7 +329,7 @@ public final class OptionalLong {
      * @return inner value if present
      * @throws X if inner value is not present
      */
-    public <X extends Throwable> long orElseThrow(Supplier<X> exceptionSupplier) throws X {
+    public <X extends Throwable> long orElseThrow(@NotNull Supplier<X> exceptionSupplier) throws X {
         if (isPresent) {
             return value;
         } else {
@@ -340,6 +355,7 @@ public final class OptionalLong {
         return isPresent ? Objects.hashCode(value) : 0;
     }
 
+    @NotNull
     @Override
     public String toString() {
         return isPresent

--- a/stream/src/main/java/com/annimon/stream/RandomCompat.java
+++ b/stream/src/main/java/com/annimon/stream/RandomCompat.java
@@ -4,6 +4,7 @@ import com.annimon.stream.function.DoubleSupplier;
 import com.annimon.stream.function.IntSupplier;
 import com.annimon.stream.function.LongSupplier;
 import java.util.Random;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Backported stream apis from {@link java.util.Random} class.
@@ -11,6 +12,7 @@ import java.util.Random;
 @SuppressWarnings("WeakerAccess")
 public final class RandomCompat {
 
+    @NotNull
     private final Random random;
 
     /**
@@ -34,7 +36,7 @@ public final class RandomCompat {
      *
      * @param random  {@code Random} instance
      */
-    public RandomCompat(Random random) {
+    public RandomCompat(@NotNull Random random) {
         this.random = random;
     }
 
@@ -43,6 +45,7 @@ public final class RandomCompat {
      *
      * @return {@link java.util.Random} object instance
      */
+    @NotNull
     public Random getRandom() {
         return random;
     }
@@ -59,6 +62,7 @@ public final class RandomCompat {
      * @throws IllegalArgumentException if {@code streamSize} is
      *         less than zero
      */
+    @NotNull
     public IntStream ints(long streamSize) {
         if (streamSize < 0L) throw new IllegalArgumentException();
         if (streamSize == 0L) {
@@ -80,6 +84,7 @@ public final class RandomCompat {
      * @throws IllegalArgumentException if {@code streamSize} is
      *         less than zero
      */
+    @NotNull
     public LongStream longs(long streamSize) {
         if (streamSize < 0L) throw new IllegalArgumentException();
         if (streamSize == 0L) {
@@ -101,6 +106,7 @@ public final class RandomCompat {
      * @throws IllegalArgumentException if {@code streamSize} is
      *         less than zero
      */
+    @NotNull
     public DoubleStream doubles(long streamSize) {
         if (streamSize < 0L) throw new IllegalArgumentException();
         if (streamSize == 0L) {
@@ -119,6 +125,7 @@ public final class RandomCompat {
      *
      * @return a stream of pseudorandom {@code int} values
      */
+    @NotNull
     public IntStream ints() {
         return IntStream.generate(new IntSupplier() {
             @Override
@@ -137,6 +144,7 @@ public final class RandomCompat {
      *
      * @return a stream of pseudorandom {@code long} values
      */
+    @NotNull
     public LongStream longs() {
         return LongStream.generate(new LongSupplier() {
             @Override
@@ -155,6 +163,7 @@ public final class RandomCompat {
      *
      * @return a stream of pseudorandom {@code double} values
      */
+    @NotNull
     public DoubleStream doubles() {
         return DoubleStream.generate(new DoubleSupplier() {
             @Override
@@ -178,6 +187,7 @@ public final class RandomCompat {
      *         less than zero, or {@code randomNumberOrigin} is
      *         greater than or equal to {@code randomNumberBound}
      */
+    @NotNull
     public IntStream ints(long streamSize, final int randomNumberOrigin, final int randomNumberBound) {
         if (streamSize < 0L) throw new IllegalArgumentException();
         if (streamSize == 0L) {
@@ -200,6 +210,7 @@ public final class RandomCompat {
      *         less than zero, or {@code randomNumberOrigin} is
      *         greater than or equal to {@code randomNumberBound}
      */
+    @NotNull
     public LongStream longs(long streamSize,
             final long randomNumberOrigin, final long randomNumberBound) {
         if (streamSize < 0L) throw new IllegalArgumentException();
@@ -223,6 +234,7 @@ public final class RandomCompat {
      *         less than zero, or {@code randomNumberOrigin} is
      *         greater than or equal to {@code randomNumberBound}
      */
+    @NotNull
     public DoubleStream doubles(long streamSize,
             final double randomNumberOrigin, final double randomNumberBound) {
         if (streamSize < 0L) throw new IllegalArgumentException();
@@ -243,6 +255,7 @@ public final class RandomCompat {
      * @throws IllegalArgumentException if {@code randomNumberOrigin}
      *         is greater than or equal to {@code randomNumberBound}
      */
+    @NotNull
     public IntStream ints(final int randomNumberOrigin, final int randomNumberBound) {
         if (randomNumberOrigin >= randomNumberBound) {
             throw new IllegalArgumentException();
@@ -277,6 +290,7 @@ public final class RandomCompat {
      * @throws IllegalArgumentException if {@code randomNumberOrigin}
      *         is greater than or equal to {@code randomNumberBound}
      */
+    @NotNull
     public LongStream longs(final long randomNumberOrigin, final long randomNumberBound) {
         if (randomNumberOrigin >= randomNumberBound) {
             throw new IllegalArgumentException();
@@ -321,6 +335,7 @@ public final class RandomCompat {
      * @throws IllegalArgumentException if {@code randomNumberOrigin}
      *         is greater than or equal to {@code randomNumberBound}
      */
+    @NotNull
     public DoubleStream doubles(final double randomNumberOrigin, final double randomNumberBound) {
         if (randomNumberOrigin >= randomNumberBound) {
             throw new IllegalArgumentException();

--- a/stream/src/main/java/com/annimon/stream/Stream.java
+++ b/stream/src/main/java/com/annimon/stream/Stream.java
@@ -1048,7 +1048,7 @@ public class Stream<T> implements Closeable {
      * @return the new stream
      */
     @NotNull
-    public Stream<T> sorted(@NotNull final Comparator<? super T> comparator) {
+    public Stream<T> sorted(@Nullable final Comparator<? super T> comparator) {
         return new Stream<T>(params, new ObjSorted<T>(iterator, comparator));
     }
 

--- a/stream/src/main/java/com/annimon/stream/Stream.java
+++ b/stream/src/main/java/com/annimon/stream/Stream.java
@@ -15,6 +15,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * A sequence of elements supporting aggregate operations.
@@ -29,6 +31,7 @@ public class Stream<T> implements Closeable {
      * @param <T> the type of the stream elements
      * @return the new empty stream
      */
+    @NotNull
     public static <T> Stream<T> empty() {
         return of(Collections.<T>emptyList());
     }
@@ -42,7 +45,8 @@ public class Stream<T> implements Closeable {
      * @return the new stream
      * @throws NullPointerException if {@code map} is null
      */
-    public static <K, V> Stream<Map.Entry<K, V>> of(Map<K, V> map) {
+    @NotNull
+    public static <K, V> Stream<Map.Entry<K, V>> of(@NotNull Map<K, V> map) {
         Objects.requireNonNull(map);
         return new Stream<Map.Entry<K, V>>(map.entrySet());
     }
@@ -55,7 +59,8 @@ public class Stream<T> implements Closeable {
      * @return the new stream
      * @throws NullPointerException if {@code iterator} is null
      */
-    public static <T> Stream<T> of(Iterator<? extends T> iterator) {
+    @NotNull
+    public static <T> Stream<T> of(@NotNull Iterator<? extends T> iterator) {
         Objects.requireNonNull(iterator);
         return new Stream<T>(iterator);
     }
@@ -68,7 +73,8 @@ public class Stream<T> implements Closeable {
      * @return the new stream
      * @throws NullPointerException if {@code iterable} is null
      */
-    public static <T> Stream<T> of(Iterable<? extends T> iterable) {
+    @NotNull
+    public static <T> Stream<T> of(@NotNull Iterable<? extends T> iterable) {
         Objects.requireNonNull(iterable);
         return new Stream<T>(iterable);
     }
@@ -81,7 +87,8 @@ public class Stream<T> implements Closeable {
      * @return the new stream
      * @throws NullPointerException if {@code elements} is null
      */
-    public static <T> Stream<T> of(final T... elements) {
+    @NotNull
+    public static <T> Stream<T> of(@NotNull final T... elements) {
         Objects.requireNonNull(elements);
         if (elements.length == 0) {
             return Stream.<T>empty();
@@ -98,8 +105,9 @@ public class Stream<T> implements Closeable {
      * @return the new stream
      * @since 1.1.5
      */
+    @NotNull
     @SuppressWarnings("unchecked")
-    public static <T> Stream<T> ofNullable(T element) {
+    public static <T> Stream<T> ofNullable(@Nullable T element) {
         return (element == null) ? Stream.<T>empty() : Stream.of(element);
     }
 
@@ -112,7 +120,8 @@ public class Stream<T> implements Closeable {
      * @return the new stream
      * @since 1.1.9
      */
-    public static <T> Stream<T> ofNullable(final T[] array) {
+    @NotNull
+    public static <T> Stream<T> ofNullable(@Nullable final T[] array) {
         return (array == null) ? Stream.<T>empty() : Stream.of(array);
     }
 
@@ -126,7 +135,8 @@ public class Stream<T> implements Closeable {
      * @return the new stream
      * @since 1.1.9
      */
-    public static <K, V> Stream<Map.Entry<K, V>> ofNullable(Map<K, V> map) {
+    @NotNull
+    public static <K, V> Stream<Map.Entry<K, V>> ofNullable(@Nullable Map<K, V> map) {
         return (map == null) ? Stream.<Map.Entry<K, V>>empty() : Stream.of(map);
     }
 
@@ -139,7 +149,8 @@ public class Stream<T> implements Closeable {
      * @return the new stream
      * @since 1.1.9
      */
-    public static <T> Stream<T> ofNullable(Iterator<? extends T> iterator) {
+    @NotNull
+    public static <T> Stream<T> ofNullable(@Nullable Iterator<? extends T> iterator) {
         return (iterator == null) ? Stream.<T>empty() : Stream.of(iterator);
     }
 
@@ -152,7 +163,8 @@ public class Stream<T> implements Closeable {
      * @return the new stream
      * @since 1.1.5
      */
-    public static <T> Stream<T> ofNullable(Iterable<? extends T> iterable) {
+    @NotNull
+    public static <T> Stream<T> ofNullable(@Nullable Iterable<? extends T> iterable) {
         return (iterable == null) ? Stream.<T>empty() : Stream.of(iterable);
     }
 
@@ -165,6 +177,7 @@ public class Stream<T> implements Closeable {
      * @return the new stream
      * @see IntStream#range(int, int)
      */
+    @NotNull
     public static Stream<Integer> range(final int from, final int to) {
         return IntStream.range(from, to).boxed();
     }
@@ -177,6 +190,7 @@ public class Stream<T> implements Closeable {
      * @param to  the upper bound (exclusive)
      * @return the new stream
      */
+    @NotNull
     public static Stream<Long> range(final long from, final long to) {
         return LongStream.range(from, to).boxed();
     }
@@ -190,6 +204,7 @@ public class Stream<T> implements Closeable {
      * @return the new stream
      * @see IntStream#rangeClosed(int, int)
      */
+    @NotNull
     public static Stream<Integer> rangeClosed(final int from, final int to) {
         return IntStream.rangeClosed(from, to).boxed();
     }
@@ -202,6 +217,7 @@ public class Stream<T> implements Closeable {
      * @param to  the upper bound (inclusive)
      * @return the new stream
      */
+    @NotNull
     public static Stream<Long> rangeClosed(final long from, final long to) {
         return LongStream.rangeClosed(from, to).boxed();
     }
@@ -214,7 +230,8 @@ public class Stream<T> implements Closeable {
      * @return the new stream
      * @throws NullPointerException if {@code supplier} is null
      */
-    public static <T> Stream<T> generate(final Supplier<T> supplier) {
+    @NotNull
+    public static <T> Stream<T> generate(@NotNull final Supplier<T> supplier) {
         Objects.requireNonNull(supplier);
         return new Stream<T>(new ObjGenerate<T>(supplier));
     }
@@ -237,7 +254,10 @@ public class Stream<T> implements Closeable {
      * @return the new stream
      * @throws NullPointerException if {@code op} is null
      */
-    public static <T> Stream<T> iterate(final T seed, final UnaryOperator<T> op) {
+    @NotNull
+    public static <T> Stream<T> iterate(
+            @Nullable final T seed,
+            @NotNull final UnaryOperator<T> op) {
         Objects.requireNonNull(op);
         return new Stream<T>(new ObjIterate<T>(seed, op));
     }
@@ -262,8 +282,11 @@ public class Stream<T> implements Closeable {
      * @throws NullPointerException if {@code op} is null
      * @since 1.1.5
      */
-    public static <T> Stream<T> iterate(final T seed,
-            final Predicate<? super T> predicate, final UnaryOperator<T> op) {
+    @NotNull
+    public static <T> Stream<T> iterate(
+            @Nullable final T seed,
+            @NotNull final Predicate<? super T> predicate,
+            @NotNull final UnaryOperator<T> op) {
         Objects.requireNonNull(predicate);
         return iterate(seed, op).takeWhile(predicate);
     }
@@ -284,7 +307,10 @@ public class Stream<T> implements Closeable {
      * @return the new concatenated stream
      * @throws NullPointerException if {@code stream1} or {@code stream2} is null
      */
-    public static <T> Stream<T> concat(Stream<? extends T> stream1, Stream<? extends T> stream2) {
+    @NotNull
+    public static <T> Stream<T> concat(
+            @NotNull Stream<? extends T> stream1,
+            @NotNull Stream<? extends T> stream2) {
         Objects.requireNonNull(stream1);
         Objects.requireNonNull(stream2);
         Stream<T> result = new Stream<T>(new ObjConcat<T>(stream1.iterator, stream2.iterator));
@@ -308,7 +334,10 @@ public class Stream<T> implements Closeable {
      * @throws NullPointerException if {@code iterator1} or {@code iterator2} is null
      * @since 1.1.9
      */
-    public static <T> Stream<T> concat(Iterator<? extends T> iterator1, Iterator<? extends T> iterator2) {
+    @NotNull
+    public static <T> Stream<T> concat(
+            @NotNull Iterator<? extends T> iterator1,
+            @NotNull Iterator<? extends T> iterator2) {
         Objects.requireNonNull(iterator1);
         Objects.requireNonNull(iterator2);
         return new Stream<T>(new ObjConcat<T>(iterator1, iterator2));
@@ -334,8 +363,11 @@ public class Stream<T> implements Closeable {
      * @return the new stream
      * @throws NullPointerException if {@code stream1} or {@code stream2} is null
      */
-    public static <F, S, R> Stream<R> zip(Stream<? extends F> stream1, Stream<? extends S> stream2,
-            final BiFunction<? super F, ? super S, ? extends R> combiner) {
+    @NotNull
+    public static <F, S, R> Stream<R> zip(
+            @NotNull Stream<? extends F> stream1,
+            @NotNull Stream<? extends S> stream2,
+            @NotNull final BiFunction<? super F, ? super S, ? extends R> combiner) {
         Objects.requireNonNull(stream1);
         Objects.requireNonNull(stream2);
         return Stream.<F, S, R>zip(stream1.iterator, stream2.iterator, combiner);
@@ -362,9 +394,11 @@ public class Stream<T> implements Closeable {
      * @throws NullPointerException if {@code iterator1} or {@code iterator2} is null
      * @since 1.1.2
      */
-    public static <F, S, R> Stream<R> zip(final Iterator<? extends F> iterator1,
-            final Iterator<? extends S> iterator2,
-            final BiFunction<? super F, ? super S, ? extends R> combiner) {
+    @NotNull
+    public static <F, S, R> Stream<R> zip(
+            @NotNull final Iterator<? extends F> iterator1,
+            @NotNull final Iterator<? extends S> iterator2,
+            @NotNull final BiFunction<? super F, ? super S, ? extends R> combiner) {
         Objects.requireNonNull(iterator1);
         Objects.requireNonNull(iterator2);
         return new Stream<R>(new ObjZip<F, S, R>(iterator1, iterator2, combiner));
@@ -397,9 +431,11 @@ public class Stream<T> implements Closeable {
      * @throws NullPointerException if {@code stream1} or {@code stream2} is null
      * @since 1.1.9
      */
+    @NotNull
     public static <T> Stream<T> merge(
-            Stream<? extends T> stream1, Stream<? extends T> stream2,
-            BiFunction<? super T, ? super T, ObjMerge.MergeResult> selector) {
+            @NotNull Stream<? extends T> stream1,
+            @NotNull Stream<? extends T> stream2,
+            @NotNull BiFunction<? super T, ? super T, ObjMerge.MergeResult> selector) {
         Objects.requireNonNull(stream1);
         Objects.requireNonNull(stream2);
         return Stream.<T>merge(stream1.iterator, stream2.iterator, selector);
@@ -433,8 +469,9 @@ public class Stream<T> implements Closeable {
      * @since 1.1.9
      */
     public static <T> Stream<T> merge(
-            Iterator<? extends T> iterator1, Iterator<? extends T> iterator2,
-            BiFunction<? super T, ? super T, ObjMerge.MergeResult> selector) {
+            @NotNull Iterator<? extends T> iterator1,
+            @NotNull Iterator<? extends T> iterator2,
+            @NotNull BiFunction<? super T, ? super T, ObjMerge.MergeResult> selector) {
         Objects.requireNonNull(iterator1);
         Objects.requireNonNull(iterator2);
         return new Stream<T>(new ObjMerge<T>(iterator1, iterator2, selector));
@@ -527,7 +564,8 @@ public class Stream<T> implements Closeable {
      * @return a result of the transforming function
      * @throws NullPointerException if {@code function} is null
      */
-    public <R> R custom(Function<Stream<T>, R> function) {
+    @Nullable
+    public <R> R custom(@NotNull Function<Stream<T>, R> function) {
         Objects.requireNonNull(function);
         return function.apply(this);
     }
@@ -547,7 +585,8 @@ public class Stream<T> implements Closeable {
      * @param predicate  the predicate used to filter elements
      * @return the new stream
      */
-    public Stream<T> filter(final Predicate<? super T> predicate) {
+    @NotNull
+    public Stream<T> filter(@NotNull final Predicate<? super T> predicate) {
         return new Stream<T>(params, new ObjFilter<T>(iterator, predicate));
     }
 
@@ -570,7 +609,8 @@ public class Stream<T> implements Closeable {
      * @return the new stream
      * @since 1.1.6
      */
-    public Stream<T> filterIndexed(IndexedPredicate<? super T> predicate) {
+    @NotNull
+    public Stream<T> filterIndexed(@NotNull IndexedPredicate<? super T> predicate) {
         return filterIndexed(0, 1, predicate);
     }
 
@@ -597,7 +637,9 @@ public class Stream<T> implements Closeable {
      * @return the new stream
      * @since 1.1.6
      */
-    public Stream<T> filterIndexed(int from, int step, IndexedPredicate<? super T> predicate) {
+    @NotNull
+    public Stream<T> filterIndexed(int from, int step,
+                                   @NotNull IndexedPredicate<? super T> predicate) {
         return new Stream<T>(params, new ObjFilterIndexed<T>(
                 new IndexedIterator<T>(from, step, iterator),
                 predicate));
@@ -611,7 +653,8 @@ public class Stream<T> implements Closeable {
      * @param predicate  the predicate used to filter elements
      * @return the new stream
      */
-    public Stream<T> filterNot(final Predicate<? super T> predicate) {
+    @NotNull
+    public Stream<T> filterNot(@NotNull final Predicate<? super T> predicate) {
         return filter(Predicate.Util.negate(predicate));
     }
 
@@ -625,8 +668,9 @@ public class Stream<T> implements Closeable {
      * @param clazz a class which instances should be selected
      * @return the new stream of type passed as parameter
      */
+    @NotNull
     @SuppressWarnings("unchecked")
-    public <TT> Stream<TT> select(final Class<TT> clazz) {
+    public <TT> Stream<TT> select(@NotNull final Class<TT> clazz) {
         return (Stream<TT>) filter(new Predicate<T>() {
             @Override
             public boolean test(T value) {
@@ -643,6 +687,7 @@ public class Stream<T> implements Closeable {
      * @return the new stream
      * @since 1.1.6
      */
+    @NotNull
     public Stream<T> withoutNulls() {
         return filter(Predicate.Util.<T>notNull());
     }
@@ -655,6 +700,7 @@ public class Stream<T> implements Closeable {
      * @return the new stream
      * @since 1.1.6
      */
+    @NotNull
     public Stream<T> nullsOnly() {
         return filterNot(Predicate.Util.<T>notNull());
     }
@@ -668,7 +714,8 @@ public class Stream<T> implements Closeable {
      * @return the new stream
      * @since 1.2.0
      */
-    public Stream<T> equalsOnly(final T object) {
+    @NotNull
+    public Stream<T> equalsOnly(@Nullable final T object) {
         return filter(new Predicate<T>() {
             @Override
             public boolean test(T value) {
@@ -693,7 +740,8 @@ public class Stream<T> implements Closeable {
      * @param mapper  the mapper function used to apply to each element
      * @return the new stream
      */
-    public <R> Stream<R> map(final Function<? super T, ? extends R> mapper) {
+    @NotNull
+    public <R> Stream<R> map(@NotNull final Function<? super T, ? extends R> mapper) {
         return new Stream<R>(params, new ObjMap<T, R>(iterator, mapper));
     }
 
@@ -715,7 +763,8 @@ public class Stream<T> implements Closeable {
      * @return the new stream
      * @since 1.1.6
      */
-    public <R> Stream<R> mapIndexed(IndexedFunction<? super T, ? extends R> mapper) {
+    @NotNull
+    public <R> Stream<R> mapIndexed(@NotNull IndexedFunction<? super T, ? extends R> mapper) {
         return this.<R>mapIndexed(0, 1, mapper);
     }
 
@@ -741,7 +790,9 @@ public class Stream<T> implements Closeable {
      * @return the new stream
      * @since 1.1.6
      */
-    public <R> Stream<R> mapIndexed(int from, int step, IndexedFunction<? super T, ? extends R> mapper) {
+    @NotNull
+    public <R> Stream<R> mapIndexed(int from, int step,
+                                    @NotNull IndexedFunction<? super T, ? extends R> mapper) {
         return new Stream<R>(params, new ObjMapIndexed<T, R>(
                 new IndexedIterator<T>(from, step, iterator),
                 mapper));
@@ -756,7 +807,8 @@ public class Stream<T> implements Closeable {
      * @return the new {@code IntStream}
      * @see #map(com.annimon.stream.function.Function)
      */
-    public IntStream mapToInt(final ToIntFunction<? super T> mapper) {
+    @NotNull
+    public IntStream mapToInt(@NotNull final ToIntFunction<? super T> mapper) {
         return new IntStream(params, new ObjMapToInt<T>(iterator, mapper));
     }
 
@@ -770,7 +822,8 @@ public class Stream<T> implements Closeable {
      * @since 1.1.4
      * @see #map(com.annimon.stream.function.Function)
      */
-    public LongStream mapToLong(final ToLongFunction<? super T> mapper) {
+    @NotNull
+    public LongStream mapToLong(@NotNull final ToLongFunction<? super T> mapper) {
         return new LongStream(params, new ObjMapToLong<T>(iterator, mapper));
     }
 
@@ -784,7 +837,8 @@ public class Stream<T> implements Closeable {
      * @since 1.1.4
      * @see #map(com.annimon.stream.function.Function)
      */
-    public DoubleStream mapToDouble(final ToDoubleFunction<? super T> mapper) {
+    @NotNull
+    public DoubleStream mapToDouble(@NotNull final ToDoubleFunction<? super T> mapper) {
         return new DoubleStream(params, new ObjMapToDouble<T>(iterator, mapper));
     }
 
@@ -806,7 +860,8 @@ public class Stream<T> implements Closeable {
      * @param mapper  the mapper function used to apply to each element
      * @return the new stream
      */
-    public <R> Stream<R> flatMap(final Function<? super T, ? extends Stream<? extends R>> mapper) {
+    @NotNull
+    public <R> Stream<R> flatMap(@NotNull final Function<? super T, ? extends Stream<? extends R>> mapper) {
         return new Stream<R>(params, new ObjFlatMap<T, R>(iterator, mapper));
     }
 
@@ -821,7 +876,8 @@ public class Stream<T> implements Closeable {
      * @return the new {@code IntStream}
      * @see #flatMap(com.annimon.stream.function.Function)
      */
-    public IntStream flatMapToInt(final Function<? super T, ? extends IntStream> mapper) {
+    @NotNull
+    public IntStream flatMapToInt(@NotNull final Function<? super T, ? extends IntStream> mapper) {
         return new IntStream(params, new ObjFlatMapToInt<T>(iterator, mapper));
     }
 
@@ -836,7 +892,8 @@ public class Stream<T> implements Closeable {
      * @return the new {@code LongStream}
      * @see #flatMap(com.annimon.stream.function.Function)
      */
-    public LongStream flatMapToLong(final Function<? super T, ? extends LongStream> mapper) {
+    @NotNull
+    public LongStream flatMapToLong(@NotNull final Function<? super T, ? extends LongStream> mapper) {
         return new LongStream(params, new ObjFlatMapToLong<T>(iterator, mapper));
     }
 
@@ -851,7 +908,8 @@ public class Stream<T> implements Closeable {
      * @return the new {@code DoubleStream}
      * @see #flatMap(com.annimon.stream.function.Function)
      */
-    public DoubleStream flatMapToDouble(final Function<? super T, ? extends DoubleStream> mapper) {
+    @NotNull
+    public DoubleStream flatMapToDouble(@NotNull final Function<? super T, ? extends DoubleStream> mapper) {
         return new DoubleStream(params, new ObjFlatMapToDouble<T>(iterator, mapper));
     }
 
@@ -870,6 +928,7 @@ public class Stream<T> implements Closeable {
      * @return the new {@code IntPair} stream
      * @since 1.1.2
      */
+    @NotNull
     public Stream<IntPair<T>> indexed() {
         return indexed(0, 1);
     }
@@ -891,9 +950,11 @@ public class Stream<T> implements Closeable {
      * @return the new {@code IntPair} stream
      * @since 1.1.2
      */
+    @NotNull
     public Stream<IntPair<T>> indexed(final int from, final int step) {
         return mapIndexed(from, step, new IndexedFunction<T, IntPair<T>>() {
 
+            @NotNull
             @Override
             public IntPair<T> apply(int index, T t) {
                 return new IntPair<T>(index, t);
@@ -914,6 +975,7 @@ public class Stream<T> implements Closeable {
      *
      * @return the new stream
      */
+    @NotNull
     public Stream<T> distinct() {
         return new Stream<T>(params, new ObjDistinct<T>(iterator));
     }
@@ -936,7 +998,8 @@ public class Stream<T> implements Closeable {
      * @return the new stream
      * @since 1.1.8
      */
-    public <K> Stream<T> distinctBy(Function<? super T, ? extends K> classifier) {
+    @NotNull
+    public <K> Stream<T> distinctBy(@NotNull Function<? super T, ? extends K> classifier) {
         return new Stream<T>(params, new ObjDistinctBy<T, K>(iterator, classifier));
     }
 
@@ -955,6 +1018,7 @@ public class Stream<T> implements Closeable {
      *
      * @return the new stream
      */
+    @NotNull
     public Stream<T> sorted() {
         return sorted(new Comparator<T>() {
 
@@ -983,7 +1047,8 @@ public class Stream<T> implements Closeable {
      * @param comparator  the {@code Comparator} to compare elements
      * @return the new stream
      */
-    public Stream<T> sorted(final Comparator<? super T> comparator) {
+    @NotNull
+    public Stream<T> sorted(@NotNull final Comparator<? super T> comparator) {
         return new Stream<T>(params, new ObjSorted<T>(iterator, comparator));
     }
 
@@ -1004,7 +1069,9 @@ public class Stream<T> implements Closeable {
      * @param f  the transformation function
      * @return the new stream
      */
-    public <R extends Comparable<? super R>> Stream<T> sortBy(final Function<? super T, ? extends R> f) {
+    @NotNull
+    public <R extends Comparable<? super R>> Stream<T> sortBy(
+            @NotNull final Function<? super T, ? extends R> f) {
         return sorted(ComparatorCompat.comparing(f));
     }
 
@@ -1024,7 +1091,9 @@ public class Stream<T> implements Closeable {
      * @param classifier  the classifier function
      * @return the new stream
      */
-    public <K> Stream<Map.Entry<K, List<T>>> groupBy(final Function<? super T, ? extends K> classifier) {
+    @NotNull
+    public <K> Stream<Map.Entry<K, List<T>>> groupBy(
+            @NotNull final Function<? super T, ? extends K> classifier) {
         Map<K, List<T>> map = collect(Collectors.<T, K>groupingBy(classifier));
         return new Stream<Map.Entry<K, List<T>>>(params, map.entrySet());
     }
@@ -1049,7 +1118,8 @@ public class Stream<T> implements Closeable {
      * @param classifier  the classifier function
      * @return the new stream
      */
-    public <K> Stream<List<T>> chunkBy(final Function<? super T, ? extends K> classifier) {
+    @NotNull
+    public <K> Stream<List<T>> chunkBy(@NotNull final Function<? super T, ? extends K> classifier) {
         return new Stream<List<T>>(params, new ObjChunkBy<T, K>(iterator, classifier));
     }
 
@@ -1069,12 +1139,13 @@ public class Stream<T> implements Closeable {
      * @return the new stream
      * @throws IllegalArgumentException if {@code stepWidth} is zero or negative
      */
+    @NotNull
     public Stream<T> sample(final int stepWidth) {
         if (stepWidth <= 0) throw new IllegalArgumentException("stepWidth cannot be zero or negative");
         if (stepWidth == 1) return this;
         return slidingWindow(1, stepWidth).map(new Function<List<T>, T>() {
             @Override
-            public T apply(List<T> list) {
+            public T apply(@NotNull List<T> list) {
                 return list.get(0);
             }
         });
@@ -1098,6 +1169,7 @@ public class Stream<T> implements Closeable {
      * @return the new stream
      * @see #slidingWindow(int, int)
      */
+    @NotNull
     public Stream<List<T>> slidingWindow(final int windowSize) {
         return slidingWindow(windowSize, 1);
     }
@@ -1132,6 +1204,7 @@ public class Stream<T> implements Closeable {
      * @throws IllegalArgumentException if {@code windowSize} is zero or negative
      * @throws IllegalArgumentException if {@code stepWidth} is zero or negative
      */
+    @NotNull
     public Stream<List<T>> slidingWindow(final int windowSize, final int stepWidth) {
         if (windowSize <= 0) throw new IllegalArgumentException("windowSize cannot be zero or negative");
         if (stepWidth <= 0) throw new IllegalArgumentException("stepWidth cannot be zero or negative");
@@ -1146,7 +1219,8 @@ public class Stream<T> implements Closeable {
      * @param action  the action to be performed on each element
      * @return the new stream
      */
-    public Stream<T> peek(final Consumer<? super T> action) {
+    @NotNull
+    public Stream<T> peek(@NotNull final Consumer<? super T> action) {
         return new Stream<T>(params, new ObjPeek<T>(iterator, action));
     }
 
@@ -1170,7 +1244,8 @@ public class Stream<T> implements Closeable {
      * @throws NullPointerException if {@code accumulator} is null
      * @since 1.1.6
      */
-    public Stream<T> scan(final BiFunction<T, T, T> accumulator) {
+    @NotNull
+    public Stream<T> scan(@NotNull final BiFunction<T, T, T> accumulator) {
         Objects.requireNonNull(accumulator);
         return new Stream<T>(params, new ObjScan<T>(iterator, accumulator));
     }
@@ -1198,7 +1273,10 @@ public class Stream<T> implements Closeable {
      * @throws NullPointerException if {@code accumulator} is null
      * @since 1.1.6
      */
-    public <R> Stream<R> scan(final R identity, final BiFunction<? super R, ? super T, ? extends R> accumulator) {
+    @NotNull
+    public <R> Stream<R> scan(
+            @Nullable final R identity,
+            @NotNull final BiFunction<? super R, ? super T, ? extends R> accumulator) {
         Objects.requireNonNull(accumulator);
         return new Stream<R>(params, new ObjScanIdentity<T, R>(iterator, identity, accumulator));
     }
@@ -1218,7 +1296,8 @@ public class Stream<T> implements Closeable {
      * @param predicate  the predicate used to take elements
      * @return the new stream
      */
-    public Stream<T> takeWhile(final Predicate<? super T> predicate) {
+    @NotNull
+    public Stream<T> takeWhile(@NotNull final Predicate<? super T> predicate) {
         return new Stream<T>(params, new ObjTakeWhile<T>(iterator, predicate));
     }
 
@@ -1240,7 +1319,8 @@ public class Stream<T> implements Closeable {
      * @return the new stream
      * @since 1.1.6
      */
-    public Stream<T> takeWhileIndexed(IndexedPredicate<? super T> predicate) {
+    @NotNull
+    public Stream<T> takeWhileIndexed(@NotNull IndexedPredicate<? super T> predicate) {
         return takeWhileIndexed(0, 1, predicate);
     }
 
@@ -1266,7 +1346,9 @@ public class Stream<T> implements Closeable {
      * @return the new stream
      * @since 1.1.6
      */
-    public Stream<T> takeWhileIndexed(int from, int step, IndexedPredicate<? super T> predicate) {
+    @NotNull
+    public Stream<T> takeWhileIndexed(int from, int step,
+                                      @NotNull IndexedPredicate<? super T> predicate) {
         return new Stream<T>(params, new ObjTakeWhileIndexed<T>(
                 new IndexedIterator<T>(from, step, iterator),
                 predicate));
@@ -1290,7 +1372,8 @@ public class Stream<T> implements Closeable {
      * @return the new stream
      * @since 1.1.6
      */
-    public Stream<T> takeUntil(final Predicate<? super T> stopPredicate) {
+    @NotNull
+    public Stream<T> takeUntil(@NotNull final Predicate<? super T> stopPredicate) {
         return new Stream<T>(params, new ObjTakeUntil<T>(iterator, stopPredicate));
     }
 
@@ -1314,7 +1397,8 @@ public class Stream<T> implements Closeable {
      * @return the new stream
      * @since 1.1.6
      */
-    public Stream<T> takeUntilIndexed(IndexedPredicate<? super T> stopPredicate) {
+    @NotNull
+    public Stream<T> takeUntilIndexed(@NotNull IndexedPredicate<? super T> stopPredicate) {
         return takeUntilIndexed(0, 1, stopPredicate);
     }
 
@@ -1342,7 +1426,9 @@ public class Stream<T> implements Closeable {
      * @return the new stream
      * @since 1.1.6
      */
-    public Stream<T> takeUntilIndexed(int from, int step, IndexedPredicate<? super T> stopPredicate) {
+    @NotNull
+    public Stream<T> takeUntilIndexed(int from, int step,
+                                      @NotNull IndexedPredicate<? super T> stopPredicate) {
         return new Stream<T>(params, new ObjTakeUntilIndexed<T>(
                 new IndexedIterator<T>(from, step, iterator),
                 stopPredicate));
@@ -1363,7 +1449,8 @@ public class Stream<T> implements Closeable {
      * @param predicate  the predicate used to drop elements
      * @return the new stream
      */
-    public Stream<T> dropWhile(final Predicate<? super T> predicate) {
+    @NotNull
+    public Stream<T> dropWhile(@NotNull final Predicate<? super T> predicate) {
         return new Stream<T>(params, new ObjDropWhile<T>(iterator, predicate));
     }
 
@@ -1385,7 +1472,8 @@ public class Stream<T> implements Closeable {
      * @return the new stream
      * @since 1.1.6
      */
-    public Stream<T> dropWhileIndexed(IndexedPredicate<? super T> predicate) {
+    @NotNull
+    public Stream<T> dropWhileIndexed(@NotNull IndexedPredicate<? super T> predicate) {
         return dropWhileIndexed(0, 1, predicate);
     }
 
@@ -1411,7 +1499,9 @@ public class Stream<T> implements Closeable {
      * @return the new stream
      * @since 1.1.6
      */
-    public Stream<T> dropWhileIndexed(int from, int step, IndexedPredicate<? super T> predicate) {
+    @NotNull
+    public Stream<T> dropWhileIndexed(int from, int step,
+                                      @NotNull IndexedPredicate<? super T> predicate) {
         return new Stream<T>(params, new ObjDropWhileIndexed<T>(
                 new IndexedIterator<T>(from, step, iterator),
                 predicate));
@@ -1437,6 +1527,7 @@ public class Stream<T> implements Closeable {
      * @return the new stream
      * @throws IllegalArgumentException if {@code maxSize} is negative
      */
+    @NotNull
     public Stream<T> limit(final long maxSize) {
         if (maxSize < 0) {
             throw new IllegalArgumentException("maxSize cannot be negative");
@@ -1468,6 +1559,7 @@ public class Stream<T> implements Closeable {
      * @return the new stream
      * @throws IllegalArgumentException if {@code n} is negative
      */
+    @NotNull
     public Stream<T> skip(final long n) {
         if (n < 0) throw new IllegalArgumentException("n cannot be negative");
         if (n == 0) return this;
@@ -1481,7 +1573,7 @@ public class Stream<T> implements Closeable {
      *
      * @param action  the action to be performed on each element
      */
-    public void forEach(final Consumer<? super T> action) {
+    public void forEach(@NotNull final Consumer<? super T> action) {
         while (iterator.hasNext()) {
             action.accept(iterator.next());
         }
@@ -1495,7 +1587,7 @@ public class Stream<T> implements Closeable {
      * @param action  the action to be performed on each element
      * @since 1.1.6
      */
-    public void forEachIndexed(IndexedConsumer<? super T> action) {
+    public void forEachIndexed(@NotNull IndexedConsumer<? super T> action) {
         forEachIndexed(0, 1, action);
     }
 
@@ -1509,7 +1601,8 @@ public class Stream<T> implements Closeable {
      * @param action  the action to be performed on each element
      * @since 1.1.6
      */
-    public void forEachIndexed(int from, int step, IndexedConsumer<? super T> action) {
+    public void forEachIndexed(int from, int step,
+                               @NotNull IndexedConsumer<? super T> action) {
         int index = from;
         while (iterator.hasNext()) {
             action.accept(index, iterator.next());
@@ -1535,7 +1628,9 @@ public class Stream<T> implements Closeable {
      * @param accumulator  the accumulation function
      * @return the result of the reduction
      */
-    public <R> R reduce(R identity, BiFunction<? super R, ? super T, ? extends R> accumulator) {
+    @Nullable
+    public <R> R reduce(@Nullable R identity,
+                        @NotNull BiFunction<? super R, ? super T, ? extends R> accumulator) {
         R result = identity;
         while (iterator.hasNext()) {
             final T value = iterator.next();
@@ -1565,7 +1660,9 @@ public class Stream<T> implements Closeable {
      * @return the result of the reduction
      * @since 1.1.6
      */
-    public <R> R reduceIndexed(R identity, IndexedBiFunction<? super R, ? super T, ? extends R> accumulator) {
+    @Nullable
+    public <R> R reduceIndexed(@Nullable R identity,
+                               @NotNull IndexedBiFunction<? super R, ? super T, ? extends R> accumulator) {
         return reduceIndexed(0, 1, identity, accumulator);
     }
 
@@ -1594,8 +1691,10 @@ public class Stream<T> implements Closeable {
      * @return the result of the reduction
      * @since 1.1.6
      */
-    public <R> R reduceIndexed(int from, int step, R identity,
-            IndexedBiFunction<? super R, ? super T, ? extends R> accumulator) {
+    @Nullable
+    public <R> R reduceIndexed(int from, int step,
+                               @Nullable R identity,
+                               @NotNull IndexedBiFunction<? super R, ? super T, ? extends R> accumulator) {
         R result = identity;
         int index = from;
         while (iterator.hasNext()) {
@@ -1615,7 +1714,8 @@ public class Stream<T> implements Closeable {
      * @return the result of the reduction
      * @see #reduce(java.lang.Object, com.annimon.stream.function.BiFunction)
      */
-    public Optional<T> reduce(BiFunction<T, T, T> accumulator) {
+    @NotNull
+    public Optional<T> reduce(@NotNull BiFunction<T, T, T> accumulator) {
         boolean foundAny = false;
         T result = null;
         while (iterator.hasNext()) {
@@ -1638,9 +1738,11 @@ public class Stream<T> implements Closeable {
      * @return the result of collect elements
      * @see #toArray(com.annimon.stream.function.IntFunction)
      */
+    @NotNull
     public Object[] toArray() {
         return toArray(new IntFunction<Object[]>() {
 
+            @NotNull
             @Override
             public Object[] apply(int value) {
                 return new Object[value];
@@ -1657,7 +1759,8 @@ public class Stream<T> implements Closeable {
      * @param generator  the array constructor reference that accommodates future array of assigned size
      * @return the result of collect elements
      */
-    public <R> R[] toArray(IntFunction<R[]> generator) {
+    @NotNull
+    public <R> R[] toArray(@NotNull IntFunction<R[]> generator) {
         return Operators.toArray(iterator, generator);
     }
 
@@ -1673,6 +1776,7 @@ public class Stream<T> implements Closeable {
      * @since 1.1.5
      * @see Collectors#toList()
      */
+    @NotNull
     public List<T> toList() {
         final List<T> result = new ArrayList<T>();
         while (iterator.hasNext()) {
@@ -1692,7 +1796,9 @@ public class Stream<T> implements Closeable {
      * @return the result of collect elements
      * @see #collect(com.annimon.stream.Collector)
      */
-    public <R> R collect(Supplier<R> supplier, BiConsumer<R, ? super T> accumulator) {
+    @Nullable
+    public <R> R collect(@NotNull Supplier<R> supplier,
+                         @NotNull BiConsumer<R, ? super T> accumulator) {
         final R result = supplier.get();
         while (iterator.hasNext()) {
             final T value = iterator.next();
@@ -1712,7 +1818,8 @@ public class Stream<T> implements Closeable {
      * @return the result of collect elements
      * @see #collect(com.annimon.stream.function.Supplier, com.annimon.stream.function.BiConsumer)
      */
-    public <R, A> R collect(Collector<? super T, A, R> collector) {
+    @Nullable
+    public <R, A> R collect(@NotNull Collector<? super T, A, R> collector) {
         A container = collector.supplier().get();
         while (iterator.hasNext()) {
             final T value = iterator.next();
@@ -1738,7 +1845,8 @@ public class Stream<T> implements Closeable {
      * @param comparator  the {@code Comparator} to compare elements
      * @return the minimum element
      */
-    public Optional<T> min(Comparator<? super T> comparator) {
+    @NotNull
+    public Optional<T> min(@NotNull Comparator<? super T> comparator) {
         return reduce(BinaryOperator.Util.<T>minBy(comparator));
     }
 
@@ -1757,7 +1865,8 @@ public class Stream<T> implements Closeable {
      * @param comparator  the {@code Comparator} to compare elements
      * @return the maximum element
      */
-    public Optional<T> max(Comparator<? super T> comparator) {
+    @NotNull
+    public Optional<T> max(@NotNull Comparator<? super T> comparator) {
         return reduce(BinaryOperator.Util.<T>maxBy(comparator));
     }
 
@@ -1796,7 +1905,7 @@ public class Stream<T> implements Closeable {
      * @param predicate  the predicate used to match elements
      * @return {@code true} if any elements match the given predicate, otherwise {@code false}
      */
-    public boolean anyMatch(Predicate<? super T> predicate) {
+    public boolean anyMatch(@NotNull Predicate<? super T> predicate) {
         return match(predicate, MATCH_ANY);
     }
 
@@ -1819,7 +1928,7 @@ public class Stream<T> implements Closeable {
      * @param predicate  the predicate used to match elements
      * @return {@code true} if all elements match the given predicate, otherwise {@code false}
      */
-    public boolean allMatch(Predicate<? super T> predicate) {
+    public boolean allMatch(@NotNull Predicate<? super T> predicate) {
         return match(predicate, MATCH_ALL);
     }
 
@@ -1842,7 +1951,7 @@ public class Stream<T> implements Closeable {
      * @param predicate  the predicate used to match elements
      * @return {@code true} if no elements match the given predicate, otherwise {@code false}
      */
-    public boolean noneMatch(Predicate<? super T> predicate) {
+    public boolean noneMatch(@NotNull Predicate<? super T> predicate) {
         return match(predicate, MATCH_NONE);
     }
 
@@ -1864,7 +1973,8 @@ public class Stream<T> implements Closeable {
      *         or {@code Optional.empty()} if stream is empty or no value was found.
      * @since 1.1.8
      */
-    public Optional<IntPair<T>> findIndexed(IndexedPredicate<? super T> predicate) {
+    @NotNull
+    public Optional<IntPair<T>> findIndexed(@NotNull IndexedPredicate<? super T> predicate) {
         return findIndexed(0, 1, predicate);
     }
 
@@ -1890,8 +2000,10 @@ public class Stream<T> implements Closeable {
      *         or {@code Optional.empty()} if stream is empty or no value was found.
      * @since 1.1.8
      */
-    public Optional<IntPair<T>> findIndexed(int from, int step,
-                                            IndexedPredicate<? super T> predicate) {
+    @NotNull
+    public Optional<IntPair<T>> findIndexed(
+            int from, int step,
+            @NotNull IndexedPredicate<? super T> predicate) {
         int index = from;
         while (iterator.hasNext()) {
             final T value = iterator.next();
@@ -1912,6 +2024,7 @@ public class Stream<T> implements Closeable {
      * @return an {@code Optional} with the first element
      *         or {@code Optional.empty()} if stream is empty
      */
+    @NotNull
     public Optional<T> findFirst() {
         if (iterator.hasNext()) {
             return Optional.of(iterator.next());
@@ -1929,6 +2042,7 @@ public class Stream<T> implements Closeable {
      *         or {@code Optional.empty()} if the stream is empty
      * @since 1.1.8
      */
+    @NotNull
     public Optional<T> findLast() {
         return reduce(new BinaryOperator<T>() {
             @Override
@@ -1962,6 +2076,7 @@ public class Stream<T> implements Closeable {
      * @throws IllegalStateException if stream contains more than one element
      * @since 1.1.2
      */
+    @Nullable
     public T single() {
         if (iterator.hasNext()) {
             T singleCandidate = iterator.next();
@@ -1998,6 +2113,7 @@ public class Stream<T> implements Closeable {
      * @throws IllegalStateException if stream contains more than one element
      * @since 1.1.2
      */
+    @NotNull
     public Optional<T> findSingle() {
         if (iterator.hasNext()) {
             T singleCandidate = iterator.next();
@@ -2020,7 +2136,8 @@ public class Stream<T> implements Closeable {
      * @return the new stream with the close handler
      * @since 1.1.8
      */
-    public Stream<T> onClose(final Runnable closeHandler) {
+    @NotNull
+    public Stream<T> onClose(@NotNull final Runnable closeHandler) {
         Objects.requireNonNull(closeHandler);
         final Params newParams;
         if (params == null) {
@@ -2053,7 +2170,7 @@ public class Stream<T> implements Closeable {
     private static final int MATCH_ALL = 1;
     private static final int MATCH_NONE = 2;
 
-    private boolean match(Predicate<? super T> predicate, int matchKind) {
+    private boolean match(@NotNull Predicate<? super T> predicate, int matchKind) {
         final boolean kindAny = (matchKind == MATCH_ANY);
         final boolean kindAll = (matchKind == MATCH_ALL);
 

--- a/stream/src/main/java/com/annimon/stream/function/BiConsumer.java
+++ b/stream/src/main/java/com/annimon/stream/function/BiConsumer.java
@@ -1,5 +1,7 @@
 package com.annimon.stream.function;
 
+import org.jetbrains.annotations.NotNull;
+
 /**
  * Represents an operation on two input arguments.
  *
@@ -34,8 +36,8 @@ public interface BiConsumer<T, U> {
          * @throws NullPointerException if {@code c1} or {@code c2} is null
          */
         public static <T, U> BiConsumer<T, U> andThen(
-                final BiConsumer<? super T, ? super U> c1,
-                final BiConsumer<? super T, ? super U> c2) {
+                @NotNull final BiConsumer<? super T, ? super U> c1,
+                @NotNull final BiConsumer<? super T, ? super U> c2) {
             return new BiConsumer<T, U>() {
                 @Override
                 public void accept(T t, U u) {

--- a/stream/src/main/java/com/annimon/stream/function/BiFunction.java
+++ b/stream/src/main/java/com/annimon/stream/function/BiFunction.java
@@ -1,6 +1,7 @@
 package com.annimon.stream.function;
 
 import com.annimon.stream.Objects;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Represents a function which produces result from two input arguments.
@@ -36,11 +37,13 @@ public interface BiFunction<T, U, R> {
          * @param f1  the {@code BiFunction} which is called first
          * @param f2  the function for transform {@code BiFunction f1} result to the type {@code V}
          * @return the result of composed function
-         * @throws NullPointerException if {@code f1} or {@code f2} or result of {@code BiFunction f1} is null
+         * @throws NullPointerException if {@code f1} or {@code f2} is null
          */
         public static <T, U, R, V> BiFunction<T, U, V> andThen(
-                final BiFunction<? super T, ? super U, ? extends R> f1,
-                final Function<? super R, ? extends V> f2) {
+                @NotNull final BiFunction<? super T, ? super U, ? extends R> f1,
+                @NotNull final Function<? super R, ? extends V> f2) {
+            Objects.requireNonNull(f1, "f1");
+            Objects.requireNonNull(f2, "f2");
             return new BiFunction<T, U, V>() {
 
                 @Override
@@ -66,7 +69,7 @@ public interface BiFunction<T, U, R> {
          * @since 1.1.6
          */
         public static <T, U, R> BiFunction<U, T, R> reverse(
-                final BiFunction<? super T, ? super U, ? extends R> function) {
+                @NotNull final BiFunction<? super T, ? super U, ? extends R> function) {
             Objects.requireNonNull(function);
             return new BiFunction<U, T, R>() {
                 @Override

--- a/stream/src/main/java/com/annimon/stream/function/BinaryOperator.java
+++ b/stream/src/main/java/com/annimon/stream/function/BinaryOperator.java
@@ -2,6 +2,7 @@ package com.annimon.stream.function;
 
 import com.annimon.stream.Objects;
 import java.util.Comparator;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Represents an operation on two operands that produces a result of the
@@ -24,7 +25,8 @@ public interface BinaryOperator<T> extends BiFunction<T, T, T> {
          *         according to the supplied {@code Comparator}
          * @throws NullPointerException if the argument is null
          */
-        public static <T> BinaryOperator<T> minBy(final Comparator<? super T> comparator) {
+        public static <T> BinaryOperator<T> minBy(
+                @NotNull final Comparator<? super T> comparator) {
             Objects.requireNonNull(comparator);
             return new BinaryOperator<T>() {
                 @Override

--- a/stream/src/main/java/com/annimon/stream/function/BooleanConsumer.java
+++ b/stream/src/main/java/com/annimon/stream/function/BooleanConsumer.java
@@ -1,5 +1,8 @@
 package com.annimon.stream.function;
 
+import com.annimon.stream.Objects;
+import org.jetbrains.annotations.NotNull;
+
 /**
  * Represents an operation on a {@code boolean}-valued input argument.
  *
@@ -29,7 +32,11 @@ public interface BooleanConsumer {
          * @return a composed {@code BooleanConsumer}
          * @throws NullPointerException if {@code c1} or {@code c2} is null
          */
-        public static BooleanConsumer andThen(final BooleanConsumer c1, final BooleanConsumer c2) {
+        public static BooleanConsumer andThen(
+                @NotNull final BooleanConsumer c1,
+                @NotNull final BooleanConsumer c2) {
+            Objects.requireNonNull(c1, "c1");
+            Objects.requireNonNull(c2, "c2");
             return new BooleanConsumer() {
                 @Override
                 public void accept(boolean value) {

--- a/stream/src/main/java/com/annimon/stream/function/BooleanPredicate.java
+++ b/stream/src/main/java/com/annimon/stream/function/BooleanPredicate.java
@@ -1,5 +1,8 @@
 package com.annimon.stream.function;
 
+import com.annimon.stream.Objects;
+import org.jetbrains.annotations.NotNull;
+
 /**
  * Represents a {@code boolean}-valued predicate (function with boolean type result).
  *
@@ -43,7 +46,11 @@ public interface BooleanPredicate {
          * @return a composed {@code BooleanPredicate}
          * @throws NullPointerException if {@code p1} or {@code p2} is null
          */
-        public static BooleanPredicate and(final BooleanPredicate p1, final BooleanPredicate p2) {
+        public static BooleanPredicate and(
+                @NotNull final BooleanPredicate p1,
+                @NotNull final BooleanPredicate p2) {
+            Objects.requireNonNull(p1, "predicate1");
+            Objects.requireNonNull(p2, "predicate2");
             return new BooleanPredicate() {
                 @Override
                 public boolean test(boolean value) {
@@ -60,7 +67,11 @@ public interface BooleanPredicate {
          * @return a composed {@code BooleanPredicate}
          * @throws NullPointerException if {@code p1} or {@code p2} is null
          */
-        public static BooleanPredicate or(final BooleanPredicate p1, final BooleanPredicate p2) {
+        public static BooleanPredicate or(
+                @NotNull final BooleanPredicate p1,
+                @NotNull final BooleanPredicate p2) {
+            Objects.requireNonNull(p1, "predicate1");
+            Objects.requireNonNull(p2, "predicate2");
             return new BooleanPredicate() {
                 @Override
                 public boolean test(boolean value) {
@@ -77,7 +88,11 @@ public interface BooleanPredicate {
          * @return a composed {@code BooleanPredicate}
          * @throws NullPointerException if {@code p1} or {@code p2} is null
          */
-        public static BooleanPredicate xor(final BooleanPredicate p1, final BooleanPredicate p2) {
+        public static BooleanPredicate xor(
+                @NotNull final BooleanPredicate p1,
+                @NotNull final BooleanPredicate p2) {
+            Objects.requireNonNull(p1, "predicate1");
+            Objects.requireNonNull(p2, "predicate2");
             return new BooleanPredicate() {
                 @Override
                 public boolean test(boolean value) {
@@ -93,7 +108,8 @@ public interface BooleanPredicate {
          * @return a composed {@code BooleanPredicate}
          * @throws NullPointerException if {@code p1} is null
          */
-        public static BooleanPredicate negate(final BooleanPredicate p1) {
+        public static BooleanPredicate negate(@NotNull final BooleanPredicate p1) {
+            Objects.requireNonNull(p1);
             return new BooleanPredicate() {
                 @Override
                 public boolean test(boolean value) {

--- a/stream/src/main/java/com/annimon/stream/function/Consumer.java
+++ b/stream/src/main/java/com/annimon/stream/function/Consumer.java
@@ -1,6 +1,8 @@
 package com.annimon.stream.function;
 
 import com.annimon.stream.Objects;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Represents an operation on input argument.
@@ -32,7 +34,11 @@ public interface Consumer<T> {
          * @return a composed {@code Consumer}
          * @throws NullPointerException if {@code c1} or {@code c2} is null
          */
-        public static <T> Consumer<T> andThen(final Consumer<? super T> c1, final Consumer<? super T> c2) {
+        public static <T> Consumer<T> andThen(
+                @NotNull final Consumer<? super T> c1,
+                @NotNull final Consumer<? super T> c2) {
+            Objects.requireNonNull(c1, "c1");
+            Objects.requireNonNull(c2, "c2");
             return new Consumer<T>() {
                 @Override
                 public void accept(T value) {
@@ -51,7 +57,8 @@ public interface Consumer<T> {
          * @throws NullPointerException if {@code throwableConsumer} is null
          * @see #safe(com.annimon.stream.function.ThrowableConsumer, com.annimon.stream.function.Consumer)
          */
-        public static <T> Consumer<T> safe(ThrowableConsumer<? super T, Throwable> throwableConsumer) {
+        public static <T> Consumer<T> safe(
+                @NotNull ThrowableConsumer<? super T, Throwable> throwableConsumer) {
             return safe(throwableConsumer, null);
         }
 
@@ -66,8 +73,9 @@ public interface Consumer<T> {
          * @see #safe(com.annimon.stream.function.ThrowableConsumer)
          */
         public static <T> Consumer<T> safe(
-                final ThrowableConsumer<? super T, Throwable> throwableConsumer,
-                final Consumer<? super T> onFailedConsumer) {
+                @NotNull final ThrowableConsumer<? super T, Throwable> throwableConsumer,
+                @Nullable final Consumer<? super T> onFailedConsumer) {
+            Objects.requireNonNull(throwableConsumer);
             return new Consumer<T>() {
 
                 @Override

--- a/stream/src/main/java/com/annimon/stream/function/DoubleConsumer.java
+++ b/stream/src/main/java/com/annimon/stream/function/DoubleConsumer.java
@@ -1,5 +1,9 @@
 package com.annimon.stream.function;
 
+import com.annimon.stream.Objects;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
 /**
  * Represents an operation on a {@code double}-valued input argument.
  *
@@ -29,7 +33,11 @@ public interface DoubleConsumer {
          * @return a composed {@code DoubleConsumer}
          * @throws NullPointerException if {@code c1} or {@code c2} is null
          */
-        public static DoubleConsumer andThen(final DoubleConsumer c1, final DoubleConsumer c2) {
+        public static DoubleConsumer andThen(
+                @NotNull final DoubleConsumer c1,
+                @NotNull final DoubleConsumer c2) {
+            Objects.requireNonNull(c1, "c1");
+            Objects.requireNonNull(c2, "c2");
             return new DoubleConsumer() {
                 @Override
                 public void accept(double value) {
@@ -48,7 +56,8 @@ public interface DoubleConsumer {
          * @since 1.1.7
          * @see #safe(com.annimon.stream.function.ThrowableDoubleConsumer, com.annimon.stream.function.DoubleConsumer)
          */
-        public static DoubleConsumer safe(ThrowableDoubleConsumer<Throwable> throwableConsumer) {
+        public static DoubleConsumer safe(
+                @NotNull ThrowableDoubleConsumer<Throwable> throwableConsumer) {
             return safe(throwableConsumer, null);
         }
 
@@ -63,8 +72,9 @@ public interface DoubleConsumer {
          * @see #safe(com.annimon.stream.function.ThrowableDoubleConsumer)
          */
         public static DoubleConsumer safe(
-                final ThrowableDoubleConsumer<Throwable> throwableConsumer,
-                final DoubleConsumer onFailedConsumer) {
+                @NotNull final ThrowableDoubleConsumer<Throwable> throwableConsumer,
+                @Nullable final DoubleConsumer onFailedConsumer) {
+            Objects.requireNonNull(throwableConsumer);
             return new DoubleConsumer() {
 
                 @Override

--- a/stream/src/main/java/com/annimon/stream/function/DoubleFunction.java
+++ b/stream/src/main/java/com/annimon/stream/function/DoubleFunction.java
@@ -1,5 +1,9 @@
 package com.annimon.stream.function;
 
+import com.annimon.stream.Objects;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
 /**
  * Represents a function which produces result from {@code double}-valued input argument.
  *
@@ -33,7 +37,7 @@ public interface DoubleFunction<R> {
          * @see #safe(com.annimon.stream.function.ThrowableDoubleFunction, java.lang.Object)
          */
         public static <R> DoubleFunction<R> safe(
-                ThrowableDoubleFunction<? extends R, Throwable> throwableFunction) {
+                @NotNull ThrowableDoubleFunction<? extends R, Throwable> throwableFunction) {
             return Util.<R>safe(throwableFunction, null);
         }
 
@@ -48,8 +52,9 @@ public interface DoubleFunction<R> {
          * @since 1.1.7
          */
         public static <R> DoubleFunction<R> safe(
-                final ThrowableDoubleFunction<? extends R, Throwable> throwableFunction,
-                final R resultIfFailed) {
+                @NotNull final ThrowableDoubleFunction<? extends R, Throwable> throwableFunction,
+                @Nullable final R resultIfFailed) {
+            Objects.requireNonNull(throwableFunction);
             return new DoubleFunction<R>() {
 
                 @Override

--- a/stream/src/main/java/com/annimon/stream/function/DoublePredicate.java
+++ b/stream/src/main/java/com/annimon/stream/function/DoublePredicate.java
@@ -1,5 +1,8 @@
 package com.annimon.stream.function;
 
+import com.annimon.stream.Objects;
+import org.jetbrains.annotations.NotNull;
+
 /**
  * Represents a {@code double}-valued predicate (function with boolean type result).
  *
@@ -28,7 +31,11 @@ public interface DoublePredicate {
          * @return a composed {@code DoublePredicate}
          * @throws NullPointerException if {@code p1} or {@code p2} is null
          */
-        public static DoublePredicate and(final DoublePredicate p1, final DoublePredicate p2) {
+        public static DoublePredicate and(
+                @NotNull final DoublePredicate p1,
+                @NotNull final DoublePredicate p2) {
+            Objects.requireNonNull(p1, "predicate1");
+            Objects.requireNonNull(p2, "predicate2");
             return new DoublePredicate() {
                 @Override
                 public boolean test(double value) {
@@ -45,7 +52,11 @@ public interface DoublePredicate {
          * @return a composed {@code DoublePredicate}
          * @throws NullPointerException if {@code p1} or {@code p2} is null
          */
-        public static DoublePredicate or(final DoublePredicate p1, final DoublePredicate p2) {
+        public static DoublePredicate or(
+                @NotNull final DoublePredicate p1,
+                @NotNull final DoublePredicate p2) {
+            Objects.requireNonNull(p1, "predicate1");
+            Objects.requireNonNull(p2, "predicate2");
             return new DoublePredicate() {
                 @Override
                 public boolean test(double value) {
@@ -62,7 +73,11 @@ public interface DoublePredicate {
          * @return a composed {@code DoublePredicate}
          * @throws NullPointerException if {@code p1} or {@code p2} is null
          */
-        public static DoublePredicate xor(final DoublePredicate p1, final DoublePredicate p2) {
+        public static DoublePredicate xor(
+                @NotNull final DoublePredicate p1,
+                @NotNull final DoublePredicate p2) {
+            Objects.requireNonNull(p1, "predicate1");
+            Objects.requireNonNull(p2, "predicate2");
             return new DoublePredicate() {
                 @Override
                 public boolean test(double value) {
@@ -78,7 +93,8 @@ public interface DoublePredicate {
          * @return a composed {@code DoublePredicate}
          * @throws NullPointerException if {@code p1} is null
          */
-        public static DoublePredicate negate(final DoublePredicate p1) {
+        public static DoublePredicate negate(@NotNull final DoublePredicate p1) {
+            Objects.requireNonNull(p1);
             return new DoublePredicate() {
                 @Override
                 public boolean test(double value) {
@@ -95,7 +111,7 @@ public interface DoublePredicate {
          * @since 1.1.7
          * @see #safe(com.annimon.stream.function.ThrowableDoublePredicate, boolean)
          */
-        public static DoublePredicate safe(ThrowableDoublePredicate<Throwable> throwablePredicate) {
+        public static DoublePredicate safe(@NotNull ThrowableDoublePredicate<Throwable> throwablePredicate) {
             return safe(throwablePredicate, false);
         }
 
@@ -109,8 +125,9 @@ public interface DoublePredicate {
          * @since 1.1.7
          */
         public static DoublePredicate safe(
-                final ThrowableDoublePredicate<Throwable> throwablePredicate,
+                @NotNull final ThrowableDoublePredicate<Throwable> throwablePredicate,
                 final boolean resultIfFailed) {
+            Objects.requireNonNull(throwablePredicate);
             return new DoublePredicate() {
 
                 @Override

--- a/stream/src/main/java/com/annimon/stream/function/DoubleSupplier.java
+++ b/stream/src/main/java/com/annimon/stream/function/DoubleSupplier.java
@@ -1,5 +1,8 @@
 package com.annimon.stream.function;
 
+import com.annimon.stream.Objects;
+import org.jetbrains.annotations.NotNull;
+
 /**
  * Represents a supplier of {@code double}-valued results.
  *
@@ -28,7 +31,8 @@ public interface DoubleSupplier {
          * @since 1.1.7
          * @see #safe(com.annimon.stream.function.ThrowableDoubleSupplier, double)
          */
-        public static DoubleSupplier safe(ThrowableDoubleSupplier<Throwable> throwableSupplier) {
+        public static DoubleSupplier safe(
+                @NotNull ThrowableDoubleSupplier<Throwable> throwableSupplier) {
             return safe(throwableSupplier, 0.0);
         }
 
@@ -42,8 +46,9 @@ public interface DoubleSupplier {
          * @since 1.1.7
          */
         public static DoubleSupplier safe(
-                final ThrowableDoubleSupplier<Throwable> throwableSupplier,
+                @NotNull final ThrowableDoubleSupplier<Throwable> throwableSupplier,
                 final double resultIfFailed) {
+            Objects.requireNonNull(throwableSupplier);
             return new DoubleSupplier() {
 
                 @Override

--- a/stream/src/main/java/com/annimon/stream/function/Function.java
+++ b/stream/src/main/java/com/annimon/stream/function/Function.java
@@ -1,5 +1,9 @@
 package com.annimon.stream.function;
 
+import com.annimon.stream.Objects;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
 /**
  * Represents a function which produces result from input arguments.
  *
@@ -31,12 +35,14 @@ public interface Function<T, R> {
          * @param f1  the function for transform {@code Function f2} result to the type {@code R}
          * @param f2  the {@code Function} which is called first
          * @return the result of composed function
-         * @throws NullPointerException if {@code f1} or {@code f2} or result of {@code Function f1} is null
+         * @throws NullPointerException if {@code f1} or {@code f2} is null
          * @see #andThen(com.annimon.stream.function.Function, com.annimon.stream.function.Function)
          */
         public static <V, T, R> Function<V, R> compose(
-                final Function<? super T, ? extends R> f1,
-                final Function<? super V, ? extends T> f2) {
+                @NotNull final Function<? super T, ? extends R> f1,
+                @NotNull final Function<? super V, ? extends T> f2) {
+            Objects.requireNonNull(f1, "f1");
+            Objects.requireNonNull(f2, "f2");
             return Util.<V, T, R>andThen(f2, f1);
         }
 
@@ -51,12 +57,14 @@ public interface Function<T, R> {
          * @param f1  the {@code Function} which is called first
          * @param f2  the function for transform {@code Function f1} result to the type {@code V}
          * @return the result of composed function
-         * @throws NullPointerException if {@code f1} or {@code f2} or result of {@code Function f1} is null
+         * @throws NullPointerException if {@code f1} or {@code f2} is null
          * @see #compose(com.annimon.stream.function.Function, com.annimon.stream.function.Function)
          */
         public static <T, R, V> Function<T, V> andThen(
-                final Function<? super T, ? extends R> f1,
-                final Function<? super R, ? extends V> f2) {
+                @NotNull final Function<? super T, ? extends R> f1,
+                @NotNull final Function<? super R, ? extends V> f2) {
+            Objects.requireNonNull(f1, "f1");
+            Objects.requireNonNull(f2, "f2");
             return new Function<T, V>() {
 
                 @Override
@@ -77,7 +85,7 @@ public interface Function<T, R> {
          * @see #safe(com.annimon.stream.function.ThrowableFunction, java.lang.Object)
          */
         public static <T, R> Function<T, R> safe(
-                ThrowableFunction<? super T, ? extends R, Throwable> throwableFunction) {
+                @NotNull ThrowableFunction<? super T, ? extends R, Throwable> throwableFunction) {
             return Util.<T, R>safe(throwableFunction, null);
         }
 
@@ -93,8 +101,9 @@ public interface Function<T, R> {
          * @see #safe(com.annimon.stream.function.ThrowableFunction)
          */
         public static <T, R> Function<T, R> safe(
-                final ThrowableFunction<? super T, ? extends R, Throwable> throwableFunction,
-                final R resultIfFailed) {
+                @NotNull final ThrowableFunction<? super T, ? extends R, Throwable> throwableFunction,
+                @Nullable final R resultIfFailed) {
+            Objects.requireNonNull(throwableFunction);
             return new Function<T, R>() {
 
                 @Override

--- a/stream/src/main/java/com/annimon/stream/function/IndexedBiFunction.java
+++ b/stream/src/main/java/com/annimon/stream/function/IndexedBiFunction.java
@@ -1,6 +1,7 @@
 package com.annimon.stream.function;
 
 import com.annimon.stream.Objects;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Represents a function which produces result from index and two input arguments.
@@ -37,7 +38,7 @@ public interface IndexedBiFunction<T, U, R> {
          * @throws NullPointerException if {@code function} is null
          */
         public static <T, U, R> IndexedBiFunction<T, U, R> wrap(
-                final BiFunction<? super T, ? super U, ? extends R> function) {
+                @NotNull final BiFunction<? super T, ? super U, ? extends R> function) {
             Objects.requireNonNull(function);
             return new IndexedBiFunction<T, U, R>() {
 

--- a/stream/src/main/java/com/annimon/stream/function/IndexedConsumer.java
+++ b/stream/src/main/java/com/annimon/stream/function/IndexedConsumer.java
@@ -1,6 +1,8 @@
 package com.annimon.stream.function;
 
 import com.annimon.stream.Objects;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Represents an operation on index and input argument.
@@ -31,7 +33,7 @@ public interface IndexedConsumer<T> {
          * @throws NullPointerException if {@code consumer} is null
          */
         public static <T> IndexedConsumer<T> wrap(
-                final Consumer<? super T> consumer) {
+                @NotNull final Consumer<? super T> consumer) {
             Objects.requireNonNull(consumer);
             return new IndexedConsumer<T>() {
 
@@ -59,7 +61,8 @@ public interface IndexedConsumer<T> {
          * @return an {@code IndexedConsumer}
          */
         public static <T> IndexedConsumer<T> accept(
-                final IntConsumer c1, final Consumer<? super T> c2) {
+                @Nullable final IntConsumer c1,
+                @Nullable final Consumer<? super T> c2) {
             return new IndexedConsumer<T>() {
 
                 @Override

--- a/stream/src/main/java/com/annimon/stream/function/IndexedDoubleConsumer.java
+++ b/stream/src/main/java/com/annimon/stream/function/IndexedDoubleConsumer.java
@@ -1,6 +1,8 @@
 package com.annimon.stream.function;
 
 import com.annimon.stream.Objects;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Represents an operation on index and input argument.
@@ -31,7 +33,11 @@ public interface IndexedDoubleConsumer {
          * @return a composed {@code IndexedDoubleConsumer}
          * @throws NullPointerException if {@code c1} or {@code c2} is null
          */
-        public static IndexedDoubleConsumer andThen(final IndexedDoubleConsumer c1, final IndexedDoubleConsumer c2) {
+        public static IndexedDoubleConsumer andThen(
+                @NotNull final IndexedDoubleConsumer c1,
+                @NotNull final IndexedDoubleConsumer c2) {
+            Objects.requireNonNull(c1, "c1");
+            Objects.requireNonNull(c2, "c2");
             return new IndexedDoubleConsumer() {
                 @Override
                 public void accept(int index, double value) {
@@ -57,7 +63,8 @@ public interface IndexedDoubleConsumer {
          * @return an {@code IndexedDoubleConsumer}
          */
         public static IndexedDoubleConsumer accept(
-                final IntConsumer c1, final DoubleConsumer c2) {
+                @Nullable final IntConsumer c1,
+                @Nullable final DoubleConsumer c2) {
             return new IndexedDoubleConsumer() {
                 @Override
                 public void accept(int index, double value) {

--- a/stream/src/main/java/com/annimon/stream/function/IndexedDoubleFunction.java
+++ b/stream/src/main/java/com/annimon/stream/function/IndexedDoubleFunction.java
@@ -1,6 +1,7 @@
 package com.annimon.stream.function;
 
 import com.annimon.stream.Objects;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Represents a function which produces result from index and input argument.
@@ -32,7 +33,7 @@ public interface IndexedDoubleFunction<R> {
          * @throws NullPointerException if {@code function} is null
          */
         public static <R> IndexedDoubleFunction<R> wrap(
-                final DoubleFunction<? extends R> function) {
+                @NotNull final DoubleFunction<? extends R> function) {
             Objects.requireNonNull(function);
             return new IndexedDoubleFunction<R>() {
                 @Override

--- a/stream/src/main/java/com/annimon/stream/function/IndexedDoublePredicate.java
+++ b/stream/src/main/java/com/annimon/stream/function/IndexedDoublePredicate.java
@@ -1,6 +1,7 @@
 package com.annimon.stream.function;
 
 import com.annimon.stream.Objects;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Represents a predicate (function with boolean type result) with additional index argument.
@@ -29,7 +30,8 @@ public interface IndexedDoublePredicate {
          * @return a wrapped {@code IndexedDoublePredicate}
          * @throws NullPointerException if {@code predicate} is null
          */
-        public static IndexedDoublePredicate wrap(final DoublePredicate predicate) {
+        public static IndexedDoublePredicate wrap(
+                @NotNull final DoublePredicate predicate) {
             Objects.requireNonNull(predicate);
             return new IndexedDoublePredicate() {
                 @Override

--- a/stream/src/main/java/com/annimon/stream/function/IndexedDoubleUnaryOperator.java
+++ b/stream/src/main/java/com/annimon/stream/function/IndexedDoubleUnaryOperator.java
@@ -1,6 +1,7 @@
 package com.annimon.stream.function;
 
 import com.annimon.stream.Objects;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Represents an operation on index and input {@code double}-valued operand
@@ -32,7 +33,7 @@ public interface IndexedDoubleUnaryOperator {
          * @throws NullPointerException if {@code function} is null
          */
         public static IndexedDoubleUnaryOperator wrap(
-                final DoubleUnaryOperator function) {
+                @NotNull final DoubleUnaryOperator function) {
             Objects.requireNonNull(function);
             return new IndexedDoubleUnaryOperator() {
                 @Override

--- a/stream/src/main/java/com/annimon/stream/function/IndexedFunction.java
+++ b/stream/src/main/java/com/annimon/stream/function/IndexedFunction.java
@@ -1,6 +1,7 @@
 package com.annimon.stream.function;
 
 import com.annimon.stream.Objects;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Represents a function which produces result from index and input argument.
@@ -34,7 +35,7 @@ public interface IndexedFunction<T, R> {
          * @throws NullPointerException if {@code function} is null
          */
         public static <T, R> IndexedFunction<T, R> wrap(
-                final Function<? super T, ? extends R> function) {
+                @NotNull final Function<? super T, ? extends R> function) {
             Objects.requireNonNull(function);
             return new IndexedFunction<T, R>() {
 

--- a/stream/src/main/java/com/annimon/stream/function/IndexedIntConsumer.java
+++ b/stream/src/main/java/com/annimon/stream/function/IndexedIntConsumer.java
@@ -1,6 +1,7 @@
 package com.annimon.stream.function;
 
 import com.annimon.stream.Objects;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Represents an operation on index and input argument.
@@ -31,7 +32,11 @@ public interface IndexedIntConsumer {
          * @return a composed {@code IndexedIntConsumer}
          * @throws NullPointerException if {@code c1} or {@code c2} is null
          */
-        public static IndexedIntConsumer andThen(final IndexedIntConsumer c1, final IndexedIntConsumer c2) {
+        public static IndexedIntConsumer andThen(
+                @NotNull final IndexedIntConsumer c1,
+                @NotNull final IndexedIntConsumer c2) {
+            Objects.requireNonNull(c1, "c1");
+            Objects.requireNonNull(c2, "c2");
             return new IndexedIntConsumer() {
                 @Override
                 public void accept(int index, int value) {

--- a/stream/src/main/java/com/annimon/stream/function/IndexedIntFunction.java
+++ b/stream/src/main/java/com/annimon/stream/function/IndexedIntFunction.java
@@ -1,6 +1,7 @@
 package com.annimon.stream.function;
 
 import com.annimon.stream.Objects;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Represents a function which produces result from index and input argument.
@@ -32,7 +33,7 @@ public interface IndexedIntFunction<R> {
          * @throws NullPointerException if {@code function} is null
          */
         public static <R> IndexedIntFunction<R> wrap(
-                final IntFunction<? extends R> function) {
+                @NotNull final IntFunction<? extends R> function) {
             Objects.requireNonNull(function);
             return new IndexedIntFunction<R>() {
                 @Override

--- a/stream/src/main/java/com/annimon/stream/function/IndexedIntPredicate.java
+++ b/stream/src/main/java/com/annimon/stream/function/IndexedIntPredicate.java
@@ -1,6 +1,7 @@
 package com.annimon.stream.function;
 
 import com.annimon.stream.Objects;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Represents a predicate (function with boolean type result) with additional index argument.
@@ -29,7 +30,7 @@ public interface IndexedIntPredicate {
          * @return a wrapped {@code IndexedIntPredicate}
          * @throws NullPointerException if {@code predicate} is null
          */
-        public static IndexedIntPredicate wrap(final IntPredicate predicate) {
+        public static IndexedIntPredicate wrap(@NotNull final IntPredicate predicate) {
             Objects.requireNonNull(predicate);
             return new IndexedIntPredicate() {
                 @Override

--- a/stream/src/main/java/com/annimon/stream/function/IndexedLongConsumer.java
+++ b/stream/src/main/java/com/annimon/stream/function/IndexedLongConsumer.java
@@ -1,6 +1,8 @@
 package com.annimon.stream.function;
 
 import com.annimon.stream.Objects;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Represents an operation on index and input argument.
@@ -31,7 +33,11 @@ public interface IndexedLongConsumer {
          * @return a composed {@code IndexedLongConsumer}
          * @throws NullPointerException if {@code c1} or {@code c2} is null
          */
-        public static IndexedLongConsumer andThen(final IndexedLongConsumer c1, final IndexedLongConsumer c2) {
+        public static IndexedLongConsumer andThen(
+                @NotNull final IndexedLongConsumer c1,
+                @NotNull final IndexedLongConsumer c2) {
+            Objects.requireNonNull(c1, "c1");
+            Objects.requireNonNull(c2, "c2");
             return new IndexedLongConsumer() {
                 @Override
                 public void accept(int index, long value) {
@@ -57,7 +63,8 @@ public interface IndexedLongConsumer {
          * @return an {@code IndexedLongConsumer}
          */
         public static IndexedLongConsumer accept(
-                final IntConsumer c1, final LongConsumer c2) {
+                @Nullable final IntConsumer c1,
+                @Nullable final LongConsumer c2) {
             return new IndexedLongConsumer() {
                 @Override
                 public void accept(int index, long value) {

--- a/stream/src/main/java/com/annimon/stream/function/IndexedLongFunction.java
+++ b/stream/src/main/java/com/annimon/stream/function/IndexedLongFunction.java
@@ -1,6 +1,7 @@
 package com.annimon.stream.function;
 
 import com.annimon.stream.Objects;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Represents a function which produces result from index and input argument.
@@ -32,7 +33,7 @@ public interface IndexedLongFunction<R> {
          * @throws NullPointerException if {@code function} is null
          */
         public static <R> IndexedLongFunction<R> wrap(
-                final LongFunction<? extends R> function) {
+                @NotNull final LongFunction<? extends R> function) {
             Objects.requireNonNull(function);
             return new IndexedLongFunction<R>() {
                 @Override

--- a/stream/src/main/java/com/annimon/stream/function/IndexedLongPredicate.java
+++ b/stream/src/main/java/com/annimon/stream/function/IndexedLongPredicate.java
@@ -1,6 +1,7 @@
 package com.annimon.stream.function;
 
 import com.annimon.stream.Objects;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Represents a predicate (function with boolean type result) with additional index argument.
@@ -29,7 +30,7 @@ public interface IndexedLongPredicate {
          * @return a wrapped {@code IndexedLongPredicate}
          * @throws NullPointerException if {@code predicate} is null
          */
-        public static IndexedLongPredicate wrap(final LongPredicate predicate) {
+        public static IndexedLongPredicate wrap(@NotNull final LongPredicate predicate) {
             Objects.requireNonNull(predicate);
             return new IndexedLongPredicate() {
                 @Override

--- a/stream/src/main/java/com/annimon/stream/function/IndexedLongUnaryOperator.java
+++ b/stream/src/main/java/com/annimon/stream/function/IndexedLongUnaryOperator.java
@@ -1,6 +1,7 @@
 package com.annimon.stream.function;
 
 import com.annimon.stream.Objects;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Represents an operation on index and input {@code long}-valued operand
@@ -32,7 +33,7 @@ public interface IndexedLongUnaryOperator {
          * @throws NullPointerException if {@code function} is null
          */
         public static IndexedLongUnaryOperator wrap(
-                final LongUnaryOperator function) {
+                @NotNull final LongUnaryOperator function) {
             Objects.requireNonNull(function);
             return new IndexedLongUnaryOperator() {
                 @Override

--- a/stream/src/main/java/com/annimon/stream/function/IndexedPredicate.java
+++ b/stream/src/main/java/com/annimon/stream/function/IndexedPredicate.java
@@ -1,6 +1,7 @@
 package com.annimon.stream.function;
 
 import com.annimon.stream.Objects;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Represents a predicate (function with boolean type result) with additional index argument.
@@ -31,7 +32,7 @@ public interface IndexedPredicate<T> {
          * @return a wrapped {@code IndexedPredicate}
          * @throws NullPointerException if {@code predicate} is null
          */
-        public static <T> IndexedPredicate<T> wrap(final Predicate<? super T> predicate) {
+        public static <T> IndexedPredicate<T> wrap(@NotNull final Predicate<? super T> predicate) {
             Objects.requireNonNull(predicate);
             return new IndexedPredicate<T>() {
                 @Override

--- a/stream/src/main/java/com/annimon/stream/function/IntConsumer.java
+++ b/stream/src/main/java/com/annimon/stream/function/IntConsumer.java
@@ -1,5 +1,9 @@
 package com.annimon.stream.function;
 
+import com.annimon.stream.Objects;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
 /**
  * Represents an operation that accepts a single {@code int}-valued argument and
  * returns no result.  This is the primitive type specialization of
@@ -33,7 +37,11 @@ public interface IntConsumer {
          * @return a composed {@code IntConsumer}
          * @throws NullPointerException if {@code c1} or {@code c2} is null
          */
-        public static IntConsumer andThen(final IntConsumer c1, final IntConsumer c2) {
+        public static IntConsumer andThen(
+                @NotNull final IntConsumer c1,
+                @NotNull final IntConsumer c2) {
+            Objects.requireNonNull(c1, "c1");
+            Objects.requireNonNull(c2, "c2");
             return new IntConsumer() {
                 @Override
                 public void accept(int value) {
@@ -52,7 +60,7 @@ public interface IntConsumer {
          * @since 1.1.7
          * @see #safe(com.annimon.stream.function.ThrowableIntConsumer, com.annimon.stream.function.IntConsumer)
          */
-        public static IntConsumer safe(ThrowableIntConsumer<Throwable> throwableConsumer) {
+        public static IntConsumer safe(@NotNull ThrowableIntConsumer<Throwable> throwableConsumer) {
             return safe(throwableConsumer, null);
         }
 
@@ -67,8 +75,9 @@ public interface IntConsumer {
          * @see #safe(com.annimon.stream.function.ThrowableIntConsumer)
          */
         public static IntConsumer safe(
-                final ThrowableIntConsumer<Throwable> throwableConsumer,
-                final IntConsumer onFailedConsumer) {
+                @NotNull final ThrowableIntConsumer<Throwable> throwableConsumer,
+                @Nullable final IntConsumer onFailedConsumer) {
+            Objects.requireNonNull(throwableConsumer);
             return new IntConsumer() {
 
                 @Override

--- a/stream/src/main/java/com/annimon/stream/function/IntFunction.java
+++ b/stream/src/main/java/com/annimon/stream/function/IntFunction.java
@@ -1,5 +1,9 @@
 package com.annimon.stream.function;
 
+import com.annimon.stream.Objects;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
 /**
  * Represents a function that accepts an int-valued argument and produces a
  * result.  This is the {@code int}-consuming primitive specialization for
@@ -37,7 +41,7 @@ public interface IntFunction<R> {
          * @see #safe(com.annimon.stream.function.ThrowableIntFunction, java.lang.Object)
          */
         public static <R> IntFunction<R> safe(
-                ThrowableIntFunction<? extends R, Throwable> throwableFunction) {
+                @NotNull ThrowableIntFunction<? extends R, Throwable> throwableFunction) {
             return Util.<R>safe(throwableFunction, null);
         }
 
@@ -52,8 +56,9 @@ public interface IntFunction<R> {
          * @since 1.1.7
          */
         public static <R> IntFunction<R> safe(
-                final ThrowableIntFunction<? extends R, Throwable> throwableFunction,
-                final R resultIfFailed) {
+                @NotNull final ThrowableIntFunction<? extends R, Throwable> throwableFunction,
+                @Nullable final R resultIfFailed) {
+            Objects.requireNonNull(throwableFunction);
             return new IntFunction<R>() {
 
                 @Override

--- a/stream/src/main/java/com/annimon/stream/function/IntPredicate.java
+++ b/stream/src/main/java/com/annimon/stream/function/IntPredicate.java
@@ -1,5 +1,8 @@
 package com.annimon.stream.function;
 
+import com.annimon.stream.Objects;
+import org.jetbrains.annotations.NotNull;
+
 /**
  * Represents a predicate (function with boolean type result).
  */
@@ -25,7 +28,11 @@ public interface IntPredicate {
          * @return a composed {@code IntPredicate}
          * @throws NullPointerException if {@code p1} or {@code p2} is null
          */
-        public static IntPredicate and(final IntPredicate p1, final IntPredicate p2) {
+        public static IntPredicate and(
+                @NotNull final IntPredicate p1,
+                @NotNull final IntPredicate p2) {
+            Objects.requireNonNull(p1, "predicate1");
+            Objects.requireNonNull(p2, "predicate2");
             return new IntPredicate() {
                 @Override
                 public boolean test(int value) {
@@ -42,7 +49,11 @@ public interface IntPredicate {
          * @return a composed {@code IntPredicate}
          * @throws NullPointerException if {@code p1} or {@code p2} is null
          */
-        public static IntPredicate or(final IntPredicate p1, final IntPredicate p2) {
+        public static IntPredicate or(
+                @NotNull final IntPredicate p1,
+                @NotNull final IntPredicate p2) {
+            Objects.requireNonNull(p1, "predicate1");
+            Objects.requireNonNull(p2, "predicate2");
             return new IntPredicate() {
                 @Override
                 public boolean test(int value) {
@@ -59,7 +70,11 @@ public interface IntPredicate {
          * @return a composed {@code IntPredicate}
          * @throws NullPointerException if {@code p1} or {@code p2} is null
          */
-        public static IntPredicate xor(final IntPredicate p1, final IntPredicate p2) {
+        public static IntPredicate xor(
+                @NotNull final IntPredicate p1,
+                @NotNull final IntPredicate p2) {
+            Objects.requireNonNull(p1, "predicate1");
+            Objects.requireNonNull(p2, "predicate2");
             return new IntPredicate() {
                 @Override
                 public boolean test(int value) {
@@ -75,7 +90,8 @@ public interface IntPredicate {
          * @return a composed {@code IntPredicate}
          * @throws NullPointerException if {@code p1} is null
          */
-        public static IntPredicate negate(final IntPredicate p1) {
+        public static IntPredicate negate(@NotNull final IntPredicate p1) {
+            Objects.requireNonNull(p1);
             return new IntPredicate() {
                 @Override
                 public boolean test(int value) {
@@ -92,7 +108,7 @@ public interface IntPredicate {
          * @since 1.1.7
          * @see #safe(com.annimon.stream.function.ThrowableIntPredicate, boolean)
          */
-        public static IntPredicate safe(ThrowableIntPredicate<Throwable> throwablePredicate) {
+        public static IntPredicate safe(@NotNull ThrowableIntPredicate<Throwable> throwablePredicate) {
             return safe(throwablePredicate, false);
         }
 
@@ -106,8 +122,9 @@ public interface IntPredicate {
          * @since 1.1.7
          */
         public static IntPredicate safe(
-                final ThrowableIntPredicate<Throwable> throwablePredicate,
+                @NotNull final ThrowableIntPredicate<Throwable> throwablePredicate,
                 final boolean resultIfFailed) {
+            Objects.requireNonNull(throwablePredicate);
             return new IntPredicate() {
 
                 @Override

--- a/stream/src/main/java/com/annimon/stream/function/IntSupplier.java
+++ b/stream/src/main/java/com/annimon/stream/function/IntSupplier.java
@@ -1,5 +1,8 @@
 package com.annimon.stream.function;
 
+import com.annimon.stream.Objects;
+import org.jetbrains.annotations.NotNull;
+
 /**
  * Represents a supplier of {@code int}-valued results.  This is the
  * {@code int}-producing primitive specialization of {@link Supplier}.
@@ -29,7 +32,8 @@ public interface IntSupplier {
          * @since 1.1.7
          * @see #safe(com.annimon.stream.function.ThrowableIntSupplier, int)
          */
-        public static IntSupplier safe(ThrowableIntSupplier<Throwable> throwableSupplier) {
+        public static IntSupplier safe(
+                @NotNull ThrowableIntSupplier<Throwable> throwableSupplier) {
             return safe(throwableSupplier, 0);
         }
 
@@ -43,8 +47,9 @@ public interface IntSupplier {
          * @since 1.1.7
          */
         public static IntSupplier safe(
-                final ThrowableIntSupplier<Throwable> throwableSupplier,
+                @NotNull final ThrowableIntSupplier<Throwable> throwableSupplier,
                 final int resultIfFailed) {
+            Objects.requireNonNull(throwableSupplier);
             return new IntSupplier() {
 
                 @Override

--- a/stream/src/main/java/com/annimon/stream/function/LongConsumer.java
+++ b/stream/src/main/java/com/annimon/stream/function/LongConsumer.java
@@ -1,5 +1,9 @@
 package com.annimon.stream.function;
 
+import com.annimon.stream.Objects;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
 /**
  * Represents an operation on a {@code long}-valued input argument.
  *
@@ -29,7 +33,11 @@ public interface LongConsumer {
          * @return a composed {@code LongConsumer}
          * @throws NullPointerException if {@code c1} or {@code c2} is null
          */
-        public static LongConsumer andThen(final LongConsumer c1, final LongConsumer c2) {
+        public static LongConsumer andThen(
+                @NotNull final LongConsumer c1,
+                @NotNull final LongConsumer c2) {
+            Objects.requireNonNull(c1, "c1");
+            Objects.requireNonNull(c2, "c2");
             return new LongConsumer() {
                 @Override
                 public void accept(long value) {
@@ -48,7 +56,8 @@ public interface LongConsumer {
          * @since 1.1.7
          * @see #safe(com.annimon.stream.function.ThrowableLongConsumer, com.annimon.stream.function.LongConsumer)
          */
-        public static LongConsumer safe(ThrowableLongConsumer<Throwable> throwableConsumer) {
+        public static LongConsumer safe(
+                @NotNull ThrowableLongConsumer<Throwable> throwableConsumer) {
             return safe(throwableConsumer, null);
         }
 
@@ -63,8 +72,9 @@ public interface LongConsumer {
          * @see #safe(com.annimon.stream.function.ThrowableLongConsumer)
          */
         public static LongConsumer safe(
-                final ThrowableLongConsumer<Throwable> throwableConsumer,
-                final LongConsumer onFailedConsumer) {
+                @NotNull final ThrowableLongConsumer<Throwable> throwableConsumer,
+                @Nullable final LongConsumer onFailedConsumer) {
+            Objects.requireNonNull(throwableConsumer);
             return new LongConsumer() {
 
                 @Override

--- a/stream/src/main/java/com/annimon/stream/function/LongFunction.java
+++ b/stream/src/main/java/com/annimon/stream/function/LongFunction.java
@@ -1,5 +1,9 @@
 package com.annimon.stream.function;
 
+import com.annimon.stream.Objects;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
 /**
  * Represents a function which produces result from {@code long}-valued input argument.
  *
@@ -33,7 +37,7 @@ public interface LongFunction<R> {
          * @see #safe(com.annimon.stream.function.ThrowableLongFunction, java.lang.Object)
          */
         public static <R> LongFunction<R> safe(
-                ThrowableLongFunction<? extends R, Throwable> throwableFunction) {
+                @NotNull ThrowableLongFunction<? extends R, Throwable> throwableFunction) {
             return Util.<R>safe(throwableFunction, null);
         }
 
@@ -48,8 +52,9 @@ public interface LongFunction<R> {
          * @since 1.1.7
          */
         public static <R> LongFunction<R> safe(
-                final ThrowableLongFunction<? extends R, Throwable> throwableFunction,
-                final R resultIfFailed) {
+                @NotNull final ThrowableLongFunction<? extends R, Throwable> throwableFunction,
+                @Nullable final R resultIfFailed) {
+            Objects.requireNonNull(throwableFunction);
             return new LongFunction<R>() {
 
                 @Override

--- a/stream/src/main/java/com/annimon/stream/function/LongPredicate.java
+++ b/stream/src/main/java/com/annimon/stream/function/LongPredicate.java
@@ -1,5 +1,8 @@
 package com.annimon.stream.function;
 
+import com.annimon.stream.Objects;
+import org.jetbrains.annotations.NotNull;
+
 /**
  * Represents a {@code long}-valued predicate (function with boolean type result).
  *
@@ -28,7 +31,11 @@ public interface LongPredicate {
          * @return a composed {@code LongPredicate}
          * @throws NullPointerException if {@code p1} or {@code p2} is null
          */
-        public static LongPredicate and(final LongPredicate p1, final LongPredicate p2) {
+        public static LongPredicate and(
+                @NotNull final LongPredicate p1,
+                @NotNull final LongPredicate p2) {
+            Objects.requireNonNull(p1, "predicate1");
+            Objects.requireNonNull(p2, "predicate2");
             return new LongPredicate() {
                 @Override
                 public boolean test(long value) {
@@ -45,7 +52,11 @@ public interface LongPredicate {
          * @return a composed {@code LongPredicate}
          * @throws NullPointerException if {@code p1} or {@code p2} is null
          */
-        public static LongPredicate or(final LongPredicate p1, final LongPredicate p2) {
+        public static LongPredicate or(
+                @NotNull final LongPredicate p1,
+                @NotNull final LongPredicate p2) {
+            Objects.requireNonNull(p1, "predicate1");
+            Objects.requireNonNull(p2, "predicate2");
             return new LongPredicate() {
                 @Override
                 public boolean test(long value) {
@@ -62,7 +73,11 @@ public interface LongPredicate {
          * @return a composed {@code LongPredicate}
          * @throws NullPointerException if {@code p1} or {@code p2} is null
          */
-        public static LongPredicate xor(final LongPredicate p1, final LongPredicate p2) {
+        public static LongPredicate xor(
+                @NotNull final LongPredicate p1,
+                @NotNull final LongPredicate p2) {
+            Objects.requireNonNull(p1, "predicate1");
+            Objects.requireNonNull(p2, "predicate2");
             return new LongPredicate() {
                 @Override
                 public boolean test(long value) {
@@ -78,7 +93,8 @@ public interface LongPredicate {
          * @return a composed {@code LongPredicate}
          * @throws NullPointerException if {@code p1} is null
          */
-        public static LongPredicate negate(final LongPredicate p1) {
+        public static LongPredicate negate(@NotNull final LongPredicate p1) {
+            Objects.requireNonNull(p1);
             return new LongPredicate() {
                 @Override
                 public boolean test(long value) {
@@ -95,7 +111,7 @@ public interface LongPredicate {
          * @since 1.1.7
          * @see #safe(com.annimon.stream.function.ThrowableLongPredicate, boolean)
          */
-        public static LongPredicate safe(ThrowableLongPredicate<Throwable> throwablePredicate) {
+        public static LongPredicate safe(@NotNull ThrowableLongPredicate<Throwable> throwablePredicate) {
             return safe(throwablePredicate, false);
         }
 
@@ -109,8 +125,9 @@ public interface LongPredicate {
          * @since 1.1.7
          */
         public static LongPredicate safe(
-                final ThrowableLongPredicate<Throwable> throwablePredicate,
+                @NotNull final ThrowableLongPredicate<Throwable> throwablePredicate,
                 final boolean resultIfFailed) {
+            Objects.requireNonNull(throwablePredicate);
             return new LongPredicate() {
 
                 @Override

--- a/stream/src/main/java/com/annimon/stream/function/LongSupplier.java
+++ b/stream/src/main/java/com/annimon/stream/function/LongSupplier.java
@@ -1,5 +1,8 @@
 package com.annimon.stream.function;
 
+import com.annimon.stream.Objects;
+import org.jetbrains.annotations.NotNull;
+
 /**
  * Represents a supplier of {@code long}-valued results.
  *
@@ -28,7 +31,7 @@ public interface LongSupplier {
          * @since 1.1.7
          * @see #safe(com.annimon.stream.function.ThrowableLongSupplier, long)
          */
-        public static LongSupplier safe(ThrowableLongSupplier<Throwable> throwableSupplier) {
+        public static LongSupplier safe(@NotNull ThrowableLongSupplier<Throwable> throwableSupplier) {
             return safe(throwableSupplier, 0L);
         }
 
@@ -42,8 +45,9 @@ public interface LongSupplier {
          * @since 1.1.7
          */
         public static LongSupplier safe(
-                final ThrowableLongSupplier<Throwable> throwableSupplier,
+                @NotNull final ThrowableLongSupplier<Throwable> throwableSupplier,
                 final long resultIfFailed) {
+            Objects.requireNonNull(throwableSupplier);
             return new LongSupplier() {
 
                 @Override

--- a/stream/src/main/java/com/annimon/stream/function/Predicate.java
+++ b/stream/src/main/java/com/annimon/stream/function/Predicate.java
@@ -2,6 +2,7 @@ package com.annimon.stream.function;
 
 import com.annimon.stream.Objects;
 import java.util.Arrays;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Represents a predicate (function with boolean type result).
@@ -31,7 +32,11 @@ public interface Predicate<T> {
          * @return a composed {@code Predicate}
          * @throws NullPointerException if {@code p1} or {@code p2} is null
          */
-        public static <T> Predicate<T> and(final Predicate<? super T> p1, final Predicate<? super T> p2) {
+        public static <T> Predicate<T> and(
+                @NotNull final Predicate<? super T> p1,
+                @NotNull final Predicate<? super T> p2) {
+            Objects.requireNonNull(p1, "predicate1");
+            Objects.requireNonNull(p2, "predicate2");
             return new Predicate<T>() {
                 @Override
                 public boolean test(T value) {
@@ -52,12 +57,12 @@ public interface Predicate<T> {
          * @since 1.2.1
          */
         public static <T> Predicate<T> and(
-                final Predicate<? super T> p1,
-                final Predicate<? super T> p2,
-                final Predicate<? super T>... rest) {
-            Objects.requireNonNull(p1);
-            Objects.requireNonNull(p2);
-            Objects.requireNonNull(rest);
+                @NotNull final Predicate<? super T> p1,
+                @NotNull final Predicate<? super T> p2,
+                @NotNull final Predicate<? super T>... rest) {
+            Objects.requireNonNull(p1, "predicate1");
+            Objects.requireNonNull(p2, "predicate2");
+            Objects.requireNonNull(rest, "rest");
             Objects.requireNonNullElements(Arrays.asList(rest));
             return new Predicate<T>() {
                 @Override
@@ -81,7 +86,11 @@ public interface Predicate<T> {
          * @return a composed {@code Predicate}
          * @throws NullPointerException if {@code p1} or {@code p2} is null
          */
-        public static <T> Predicate<T> or(final Predicate<? super T> p1, final Predicate<? super T> p2) {
+        public static <T> Predicate<T> or(
+                @NotNull final Predicate<? super T> p1,
+                @NotNull final Predicate<? super T> p2) {
+            Objects.requireNonNull(p1, "predicate1");
+            Objects.requireNonNull(p2, "predicate2");
             return new Predicate<T>() {
                 @Override
                 public boolean test(T value) {
@@ -101,12 +110,12 @@ public interface Predicate<T> {
          * @throws NullPointerException if any of predicates are null
          */
         public static <T> Predicate<T> or(
-                final Predicate<? super T> p1,
-                final Predicate<? super T> p2,
-                final Predicate<? super T>... rest) {
-            Objects.requireNonNull(p1);
-            Objects.requireNonNull(p2);
-            Objects.requireNonNull(rest);
+                @NotNull final Predicate<? super T> p1,
+                @NotNull final Predicate<? super T> p2,
+                @NotNull final Predicate<? super T>... rest) {
+            Objects.requireNonNull(p1, "predicate1");
+            Objects.requireNonNull(p2, "predicate2");
+            Objects.requireNonNull(rest, "rest");
             Objects.requireNonNullElements(Arrays.asList(rest));
             return new Predicate<T>() {
                 @Override
@@ -130,7 +139,11 @@ public interface Predicate<T> {
          * @return a composed {@code Predicate}
          * @throws NullPointerException if {@code p1} or {@code p2} is null
          */
-        public static <T> Predicate<T> xor(final Predicate<? super T> p1, final Predicate<? super T> p2) {
+        public static <T> Predicate<T> xor(
+                @NotNull final Predicate<? super T> p1,
+                @NotNull final Predicate<? super T> p2) {
+            Objects.requireNonNull(p1, "predicate1");
+            Objects.requireNonNull(p2, "predicate2");
             return new Predicate<T>() {
                 @Override
                 public boolean test(T value) {
@@ -143,15 +156,16 @@ public interface Predicate<T> {
          * Applies logical negation to predicate.
          *
          * @param <T> the type of the input to the function
-         * @param p1  the predicate to be negated
+         * @param predicate  the predicate to be negated
          * @return a composed {@code Predicate}
          * @throws NullPointerException if {@code p1} is null
          */
-        public static <T> Predicate<T> negate(final Predicate<? super T> p1) {
+        public static <T> Predicate<T> negate(@NotNull final Predicate<? super T> predicate) {
+            Objects.requireNonNull(predicate);
             return new Predicate<T>() {
                 @Override
                 public boolean test(T value) {
-                    return !p1.test(value);
+                    return !predicate.test(value);
                 }
             };
         }
@@ -178,7 +192,8 @@ public interface Predicate<T> {
          * @param throwablePredicate  the predicate that may throw an exception
          * @return a {@code Predicate} or {@code false} if exception was thrown
          */
-        public static <T> Predicate<T> safe(ThrowablePredicate<? super T, Throwable> throwablePredicate) {
+        public static <T> Predicate<T> safe(
+                @NotNull ThrowablePredicate<? super T, Throwable> throwablePredicate) {
             return safe(throwablePredicate, false);
         }
 
@@ -192,8 +207,9 @@ public interface Predicate<T> {
          * @throws NullPointerException if {@code throwablePredicate} is null
          */
         public static <T> Predicate<T> safe(
-                final ThrowablePredicate<? super T, Throwable> throwablePredicate,
+                @NotNull final ThrowablePredicate<? super T, Throwable> throwablePredicate,
                 final boolean resultIfFailed) {
+            Objects.requireNonNull(throwablePredicate);
             return new Predicate<T>() {
 
                 @Override

--- a/stream/src/main/java/com/annimon/stream/function/Supplier.java
+++ b/stream/src/main/java/com/annimon/stream/function/Supplier.java
@@ -1,5 +1,9 @@
 package com.annimon.stream.function;
 
+import com.annimon.stream.Objects;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
 /**
  * Represents a function which supply a result.
  *
@@ -28,7 +32,8 @@ public interface Supplier<T> {
          * @since 1.1.7
          * @see #safe(com.annimon.stream.function.ThrowableSupplier, java.lang.Object)
          */
-        public static <T> Supplier<T> safe(ThrowableSupplier<? extends T, Throwable> throwableSupplier) {
+        public static <T> Supplier<T> safe(
+                @NotNull ThrowableSupplier<? extends T, Throwable> throwableSupplier) {
             return Util.<T>safe(throwableSupplier, null);
         }
 
@@ -43,8 +48,9 @@ public interface Supplier<T> {
          * @since 1.1.7
          */
         public static <T> Supplier<T> safe(
-                final ThrowableSupplier<? extends T, Throwable> throwableSupplier,
-                final T resultIfFailed) {
+                @NotNull final ThrowableSupplier<? extends T, Throwable> throwableSupplier,
+                @Nullable final T resultIfFailed) {
+            Objects.requireNonNull(throwableSupplier);
             return new Supplier<T>() {
 
                 @Override

--- a/stream/src/main/java/com/annimon/stream/internal/Compat.java
+++ b/stream/src/main/java/com/annimon/stream/internal/Compat.java
@@ -5,6 +5,7 @@ import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.Queue;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Compatibility methods for Android API &lt; 9.
@@ -14,6 +15,7 @@ public final class Compat {
     static final long MAX_ARRAY_SIZE = Integer.MAX_VALUE - 8;
     private static final String BAD_SIZE = "Stream size exceeds max array size";
 
+    @NotNull
     public static <T> Queue<T> queue() {
         // ArrayDeque was introduced in Android 2.3
         try {

--- a/stream/src/main/java/com/annimon/stream/internal/Operators.java
+++ b/stream/src/main/java/com/annimon/stream/internal/Operators.java
@@ -5,12 +5,14 @@ import com.annimon.stream.iterator.PrimitiveIterator;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import org.jetbrains.annotations.NotNull;
 
 public final class Operators {
 
     private Operators() {}
 
-    public static <T> List<T> toList(Iterator<? extends T> iterator) {
+    @NotNull
+    public static <T> List<T> toList(@NotNull Iterator<? extends T> iterator) {
         final List<T> result = new ArrayList<T>();
         while (iterator.hasNext()) {
             result.add(iterator.next());
@@ -18,8 +20,10 @@ public final class Operators {
         return result;
     }
 
+    @NotNull
     @SuppressWarnings("unchecked")
-    public static <T, R> R[] toArray(Iterator<? extends T> iterator, IntFunction<R[]> generator) {
+    public static <T, R> R[] toArray(@NotNull Iterator<? extends T> iterator,
+                                     @NotNull IntFunction<R[]> generator) {
         final List<T> container = Operators.<T>toList(iterator);
         final int size = container.size();
 
@@ -34,7 +38,8 @@ public final class Operators {
         return boxed;
     }
 
-    public static int[] toIntArray(PrimitiveIterator.OfInt iterator) {
+    @NotNull
+    public static int[] toIntArray(@NotNull PrimitiveIterator.OfInt iterator) {
         final SpinedBuffer.OfInt b = new SpinedBuffer.OfInt();
         while (iterator.hasNext()) {
             b.accept(iterator.nextInt());
@@ -42,7 +47,8 @@ public final class Operators {
         return b.asPrimitiveArray();
     }
 
-    public static long[] toLongArray(PrimitiveIterator.OfLong iterator) {
+    @NotNull
+    public static long[] toLongArray(@NotNull PrimitiveIterator.OfLong iterator) {
         final SpinedBuffer.OfLong b = new SpinedBuffer.OfLong();
         while (iterator.hasNext()) {
             b.accept(iterator.nextLong());
@@ -50,7 +56,8 @@ public final class Operators {
         return b.asPrimitiveArray();
     }
 
-    public static double[] toDoubleArray(PrimitiveIterator.OfDouble iterator) {
+    @NotNull
+    public static double[] toDoubleArray(@NotNull PrimitiveIterator.OfDouble iterator) {
         final SpinedBuffer.OfDouble b = new SpinedBuffer.OfDouble();
         while (iterator.hasNext()) {
             b.accept(iterator.nextDouble());

--- a/stream/src/main/java/com/annimon/stream/operator/DoubleArray.java
+++ b/stream/src/main/java/com/annimon/stream/operator/DoubleArray.java
@@ -1,13 +1,14 @@
 package com.annimon.stream.operator;
 
 import com.annimon.stream.iterator.PrimitiveIterator;
+import org.jetbrains.annotations.NotNull;
 
 public class DoubleArray extends PrimitiveIterator.OfDouble {
 
     private final double[] values;
     private int index;
 
-    public DoubleArray(double[] values) {
+    public DoubleArray(@NotNull double[] values) {
         this.values = values;
         index = 0;
     }

--- a/stream/src/main/java/com/annimon/stream/operator/DoubleConcat.java
+++ b/stream/src/main/java/com/annimon/stream/operator/DoubleConcat.java
@@ -1,6 +1,7 @@
 package com.annimon.stream.operator;
 
 import com.annimon.stream.iterator.PrimitiveIterator;
+import org.jetbrains.annotations.NotNull;
 
 public class DoubleConcat extends PrimitiveIterator.OfDouble {
 
@@ -8,7 +9,9 @@ public class DoubleConcat extends PrimitiveIterator.OfDouble {
     private final PrimitiveIterator.OfDouble iterator2;
     private boolean firstStreamIsCurrent;
 
-    public DoubleConcat(PrimitiveIterator.OfDouble iterator1, PrimitiveIterator.OfDouble iterator2) {
+    public DoubleConcat(
+            @NotNull PrimitiveIterator.OfDouble iterator1,
+            @NotNull PrimitiveIterator.OfDouble iterator2) {
         this.iterator1 = iterator1;
         this.iterator2 = iterator2;
         firstStreamIsCurrent = true;

--- a/stream/src/main/java/com/annimon/stream/operator/DoubleDropWhile.java
+++ b/stream/src/main/java/com/annimon/stream/operator/DoubleDropWhile.java
@@ -3,13 +3,16 @@ package com.annimon.stream.operator;
 import com.annimon.stream.function.DoublePredicate;
 import com.annimon.stream.iterator.PrimitiveExtIterator;
 import com.annimon.stream.iterator.PrimitiveIterator;
+import org.jetbrains.annotations.NotNull;
 
 public class DoubleDropWhile extends PrimitiveExtIterator.OfDouble {
 
     private final PrimitiveIterator.OfDouble iterator;
     private final DoublePredicate predicate;
 
-    public DoubleDropWhile(PrimitiveIterator.OfDouble iterator, DoublePredicate predicate) {
+    public DoubleDropWhile(
+            @NotNull PrimitiveIterator.OfDouble iterator,
+            @NotNull DoublePredicate predicate) {
         this.iterator = iterator;
         this.predicate = predicate;
     }

--- a/stream/src/main/java/com/annimon/stream/operator/DoubleFilter.java
+++ b/stream/src/main/java/com/annimon/stream/operator/DoubleFilter.java
@@ -3,6 +3,7 @@ package com.annimon.stream.operator;
 import com.annimon.stream.function.DoublePredicate;
 import com.annimon.stream.iterator.PrimitiveIterator;
 import java.util.NoSuchElementException;
+import org.jetbrains.annotations.NotNull;
 
 public class DoubleFilter extends PrimitiveIterator.OfDouble {
 
@@ -11,7 +12,9 @@ public class DoubleFilter extends PrimitiveIterator.OfDouble {
     private boolean hasNext, hasNextEvaluated;
     private double next;
 
-    public DoubleFilter(PrimitiveIterator.OfDouble iterator, DoublePredicate predicate) {
+    public DoubleFilter(
+            @NotNull PrimitiveIterator.OfDouble iterator,
+            @NotNull DoublePredicate predicate) {
         this.iterator = iterator;
         this.predicate = predicate;
     }

--- a/stream/src/main/java/com/annimon/stream/operator/DoubleFilterIndexed.java
+++ b/stream/src/main/java/com/annimon/stream/operator/DoubleFilterIndexed.java
@@ -4,6 +4,7 @@ import com.annimon.stream.function.IndexedDoublePredicate;
 import com.annimon.stream.iterator.PrimitiveIndexedIterator;
 import com.annimon.stream.iterator.PrimitiveIterator;
 import java.util.NoSuchElementException;
+import org.jetbrains.annotations.NotNull;
 
 public class DoubleFilterIndexed extends PrimitiveIterator.OfDouble {
 
@@ -12,7 +13,9 @@ public class DoubleFilterIndexed extends PrimitiveIterator.OfDouble {
     private boolean hasNext, hasNextEvaluated;
     private double next;
 
-    public DoubleFilterIndexed(PrimitiveIndexedIterator.OfDouble iterator, IndexedDoublePredicate predicate) {
+    public DoubleFilterIndexed(
+            @NotNull PrimitiveIndexedIterator.OfDouble iterator,
+            @NotNull IndexedDoublePredicate predicate) {
         this.iterator = iterator;
         this.predicate = predicate;
     }

--- a/stream/src/main/java/com/annimon/stream/operator/DoubleFlatMap.java
+++ b/stream/src/main/java/com/annimon/stream/operator/DoubleFlatMap.java
@@ -4,6 +4,7 @@ import com.annimon.stream.DoubleStream;
 import com.annimon.stream.function.DoubleFunction;
 import com.annimon.stream.iterator.PrimitiveIterator;
 import java.util.NoSuchElementException;
+import org.jetbrains.annotations.NotNull;
 
 public class DoubleFlatMap extends PrimitiveIterator.OfDouble {
 
@@ -12,7 +13,9 @@ public class DoubleFlatMap extends PrimitiveIterator.OfDouble {
     private PrimitiveIterator.OfDouble inner;
     private DoubleStream innerStream;
 
-    public DoubleFlatMap(PrimitiveIterator.OfDouble iterator, DoubleFunction<? extends DoubleStream> mapper) {
+    public DoubleFlatMap(
+            @NotNull PrimitiveIterator.OfDouble iterator,
+            @NotNull DoubleFunction<? extends DoubleStream> mapper) {
         this.iterator = iterator;
         this.mapper = mapper;
     }

--- a/stream/src/main/java/com/annimon/stream/operator/DoubleGenerate.java
+++ b/stream/src/main/java/com/annimon/stream/operator/DoubleGenerate.java
@@ -2,12 +2,13 @@ package com.annimon.stream.operator;
 
 import com.annimon.stream.function.DoubleSupplier;
 import com.annimon.stream.iterator.PrimitiveIterator;
+import org.jetbrains.annotations.NotNull;
 
 public class DoubleGenerate extends PrimitiveIterator.OfDouble {
 
     private final DoubleSupplier supplier;
 
-    public DoubleGenerate(DoubleSupplier supplier) {
+    public DoubleGenerate(@NotNull DoubleSupplier supplier) {
         this.supplier = supplier;
     }
 

--- a/stream/src/main/java/com/annimon/stream/operator/DoubleIterate.java
+++ b/stream/src/main/java/com/annimon/stream/operator/DoubleIterate.java
@@ -2,13 +2,14 @@ package com.annimon.stream.operator;
 
 import com.annimon.stream.function.DoubleUnaryOperator;
 import com.annimon.stream.iterator.PrimitiveIterator;
+import org.jetbrains.annotations.NotNull;
 
 public class DoubleIterate extends PrimitiveIterator.OfDouble {
 
     private final DoubleUnaryOperator op;
     private double current;
 
-    public DoubleIterate(double seed, DoubleUnaryOperator f) {
+    public DoubleIterate(double seed, @NotNull DoubleUnaryOperator f) {
         this.op = f;
         current = seed;
     }

--- a/stream/src/main/java/com/annimon/stream/operator/DoubleLimit.java
+++ b/stream/src/main/java/com/annimon/stream/operator/DoubleLimit.java
@@ -1,6 +1,7 @@
 package com.annimon.stream.operator;
 
 import com.annimon.stream.iterator.PrimitiveIterator;
+import org.jetbrains.annotations.NotNull;
 
 public class DoubleLimit extends PrimitiveIterator.OfDouble {
 
@@ -8,7 +9,7 @@ public class DoubleLimit extends PrimitiveIterator.OfDouble {
     private final long maxSize;
     private long index;
 
-    public DoubleLimit(PrimitiveIterator.OfDouble iterator, long maxSize) {
+    public DoubleLimit(@NotNull PrimitiveIterator.OfDouble iterator, long maxSize) {
         this.iterator = iterator;
         this.maxSize = maxSize;
         index = 0;

--- a/stream/src/main/java/com/annimon/stream/operator/DoubleMap.java
+++ b/stream/src/main/java/com/annimon/stream/operator/DoubleMap.java
@@ -2,13 +2,16 @@ package com.annimon.stream.operator;
 
 import com.annimon.stream.function.DoubleUnaryOperator;
 import com.annimon.stream.iterator.PrimitiveIterator;
+import org.jetbrains.annotations.NotNull;
 
 public class DoubleMap extends PrimitiveIterator.OfDouble {
 
     private final PrimitiveIterator.OfDouble iterator;
     private final DoubleUnaryOperator mapper;
 
-    public DoubleMap(PrimitiveIterator.OfDouble iterator, DoubleUnaryOperator mapper) {
+    public DoubleMap(
+            @NotNull PrimitiveIterator.OfDouble iterator,
+            @NotNull DoubleUnaryOperator mapper) {
         this.iterator = iterator;
         this.mapper = mapper;
     }

--- a/stream/src/main/java/com/annimon/stream/operator/DoubleMapIndexed.java
+++ b/stream/src/main/java/com/annimon/stream/operator/DoubleMapIndexed.java
@@ -3,13 +3,16 @@ package com.annimon.stream.operator;
 import com.annimon.stream.function.IndexedDoubleUnaryOperator;
 import com.annimon.stream.iterator.PrimitiveIndexedIterator;
 import com.annimon.stream.iterator.PrimitiveIterator;
+import org.jetbrains.annotations.NotNull;
 
 public class DoubleMapIndexed extends PrimitiveIterator.OfDouble {
 
     private final PrimitiveIndexedIterator.OfDouble iterator;
     private final IndexedDoubleUnaryOperator mapper;
 
-    public DoubleMapIndexed(PrimitiveIndexedIterator.OfDouble iterator, IndexedDoubleUnaryOperator mapper) {
+    public DoubleMapIndexed(
+            @NotNull PrimitiveIndexedIterator.OfDouble iterator,
+            @NotNull IndexedDoubleUnaryOperator mapper) {
         this.iterator = iterator;
         this.mapper = mapper;
     }

--- a/stream/src/main/java/com/annimon/stream/operator/DoubleMapToInt.java
+++ b/stream/src/main/java/com/annimon/stream/operator/DoubleMapToInt.java
@@ -2,13 +2,16 @@ package com.annimon.stream.operator;
 
 import com.annimon.stream.function.DoubleToIntFunction;
 import com.annimon.stream.iterator.PrimitiveIterator;
+import org.jetbrains.annotations.NotNull;
 
 public class DoubleMapToInt extends PrimitiveIterator.OfInt {
 
     private final PrimitiveIterator.OfDouble iterator;
     private final DoubleToIntFunction mapper;
 
-    public DoubleMapToInt(PrimitiveIterator.OfDouble iterator, DoubleToIntFunction mapper) {
+    public DoubleMapToInt(
+            @NotNull PrimitiveIterator.OfDouble iterator,
+            @NotNull DoubleToIntFunction mapper) {
         this.iterator = iterator;
         this.mapper = mapper;
     }

--- a/stream/src/main/java/com/annimon/stream/operator/DoubleMapToLong.java
+++ b/stream/src/main/java/com/annimon/stream/operator/DoubleMapToLong.java
@@ -2,13 +2,16 @@ package com.annimon.stream.operator;
 
 import com.annimon.stream.function.DoubleToLongFunction;
 import com.annimon.stream.iterator.PrimitiveIterator;
+import org.jetbrains.annotations.NotNull;
 
 public class DoubleMapToLong extends PrimitiveIterator.OfLong {
 
     private final PrimitiveIterator.OfDouble iterator;
     private final DoubleToLongFunction mapper;
 
-    public DoubleMapToLong(PrimitiveIterator.OfDouble iterator, DoubleToLongFunction mapper) {
+    public DoubleMapToLong(
+            @NotNull PrimitiveIterator.OfDouble iterator,
+            @NotNull DoubleToLongFunction mapper) {
         this.iterator = iterator;
         this.mapper = mapper;
     }

--- a/stream/src/main/java/com/annimon/stream/operator/DoubleMapToObj.java
+++ b/stream/src/main/java/com/annimon/stream/operator/DoubleMapToObj.java
@@ -3,13 +3,16 @@ package com.annimon.stream.operator;
 import com.annimon.stream.function.DoubleFunction;
 import com.annimon.stream.iterator.LsaIterator;
 import com.annimon.stream.iterator.PrimitiveIterator;
+import org.jetbrains.annotations.NotNull;
 
 public class DoubleMapToObj<R> extends LsaIterator<R> {
 
     private final PrimitiveIterator.OfDouble iterator;
     private final DoubleFunction<? extends R> mapper;
 
-    public DoubleMapToObj(PrimitiveIterator.OfDouble iterator, DoubleFunction<? extends R> mapper) {
+    public DoubleMapToObj(
+            @NotNull PrimitiveIterator.OfDouble iterator,
+            @NotNull DoubleFunction<? extends R> mapper) {
         this.iterator = iterator;
         this.mapper = mapper;
     }

--- a/stream/src/main/java/com/annimon/stream/operator/DoublePeek.java
+++ b/stream/src/main/java/com/annimon/stream/operator/DoublePeek.java
@@ -2,13 +2,16 @@ package com.annimon.stream.operator;
 
 import com.annimon.stream.function.DoubleConsumer;
 import com.annimon.stream.iterator.PrimitiveIterator;
+import org.jetbrains.annotations.NotNull;
 
 public class DoublePeek extends PrimitiveIterator.OfDouble {
 
     private final PrimitiveIterator.OfDouble iterator;
     private final DoubleConsumer action;
 
-    public DoublePeek(PrimitiveIterator.OfDouble iterator, DoubleConsumer action) {
+    public DoublePeek(
+            @NotNull PrimitiveIterator.OfDouble iterator,
+            @NotNull DoubleConsumer action) {
         this.iterator = iterator;
         this.action = action;
     }

--- a/stream/src/main/java/com/annimon/stream/operator/DoubleSample.java
+++ b/stream/src/main/java/com/annimon/stream/operator/DoubleSample.java
@@ -1,13 +1,14 @@
 package com.annimon.stream.operator;
 
 import com.annimon.stream.iterator.PrimitiveIterator;
+import org.jetbrains.annotations.NotNull;
 
 public class DoubleSample extends PrimitiveIterator.OfDouble {
 
     private final PrimitiveIterator.OfDouble iterator;
     private final int stepWidth;
 
-    public DoubleSample(PrimitiveIterator.OfDouble iterator, int stepWidth) {
+    public DoubleSample(@NotNull PrimitiveIterator.OfDouble iterator, int stepWidth) {
         this.iterator = iterator;
         this.stepWidth = stepWidth;
     }

--- a/stream/src/main/java/com/annimon/stream/operator/DoubleScan.java
+++ b/stream/src/main/java/com/annimon/stream/operator/DoubleScan.java
@@ -3,13 +3,16 @@ package com.annimon.stream.operator;
 import com.annimon.stream.function.DoubleBinaryOperator;
 import com.annimon.stream.iterator.PrimitiveExtIterator;
 import com.annimon.stream.iterator.PrimitiveIterator;
+import org.jetbrains.annotations.NotNull;
 
 public class DoubleScan extends PrimitiveExtIterator.OfDouble {
 
     private final PrimitiveIterator.OfDouble iterator;
     private final DoubleBinaryOperator accumulator;
 
-    public DoubleScan(PrimitiveIterator.OfDouble iterator, DoubleBinaryOperator accumulator) {
+    public DoubleScan(
+            @NotNull PrimitiveIterator.OfDouble iterator,
+            @NotNull DoubleBinaryOperator accumulator) {
         this.iterator = iterator;
         this.accumulator = accumulator;
     }

--- a/stream/src/main/java/com/annimon/stream/operator/DoubleScanIdentity.java
+++ b/stream/src/main/java/com/annimon/stream/operator/DoubleScanIdentity.java
@@ -3,6 +3,7 @@ package com.annimon.stream.operator;
 import com.annimon.stream.function.DoubleBinaryOperator;
 import com.annimon.stream.iterator.PrimitiveExtIterator;
 import com.annimon.stream.iterator.PrimitiveIterator;
+import org.jetbrains.annotations.NotNull;
 
 public class DoubleScanIdentity extends PrimitiveExtIterator.OfDouble {
 
@@ -10,8 +11,10 @@ public class DoubleScanIdentity extends PrimitiveExtIterator.OfDouble {
     private final double identity;
     private final DoubleBinaryOperator accumulator;
 
-    public DoubleScanIdentity(PrimitiveIterator.OfDouble iterator, double identity,
-            DoubleBinaryOperator accumulator) {
+    public DoubleScanIdentity(
+            @NotNull PrimitiveIterator.OfDouble iterator,
+            double identity,
+            @NotNull DoubleBinaryOperator accumulator) {
         this.iterator = iterator;
         this.identity = identity;
         this.accumulator = accumulator;

--- a/stream/src/main/java/com/annimon/stream/operator/DoubleSkip.java
+++ b/stream/src/main/java/com/annimon/stream/operator/DoubleSkip.java
@@ -1,6 +1,7 @@
 package com.annimon.stream.operator;
 
 import com.annimon.stream.iterator.PrimitiveIterator;
+import org.jetbrains.annotations.NotNull;
 
 public class DoubleSkip extends PrimitiveIterator.OfDouble {
 
@@ -8,7 +9,7 @@ public class DoubleSkip extends PrimitiveIterator.OfDouble {
     private final long n;
     private long skipped;
 
-    public DoubleSkip(PrimitiveIterator.OfDouble iterator, long n) {
+    public DoubleSkip(@NotNull PrimitiveIterator.OfDouble iterator, long n) {
         this.iterator = iterator;
         this.n = n;
         skipped = 0;

--- a/stream/src/main/java/com/annimon/stream/operator/DoubleSorted.java
+++ b/stream/src/main/java/com/annimon/stream/operator/DoubleSorted.java
@@ -4,6 +4,7 @@ import com.annimon.stream.internal.Operators;
 import com.annimon.stream.iterator.PrimitiveExtIterator;
 import com.annimon.stream.iterator.PrimitiveIterator;
 import java.util.Arrays;
+import org.jetbrains.annotations.NotNull;
 
 public class DoubleSorted extends PrimitiveExtIterator.OfDouble {
 
@@ -11,7 +12,7 @@ public class DoubleSorted extends PrimitiveExtIterator.OfDouble {
     private int index;
     private double[] array;
 
-    public DoubleSorted(PrimitiveIterator.OfDouble iterator) {
+    public DoubleSorted(@NotNull PrimitiveIterator.OfDouble iterator) {
         this.iterator = iterator;
         index = 0;
     }

--- a/stream/src/main/java/com/annimon/stream/operator/DoubleTakeUntil.java
+++ b/stream/src/main/java/com/annimon/stream/operator/DoubleTakeUntil.java
@@ -3,13 +3,16 @@ package com.annimon.stream.operator;
 import com.annimon.stream.function.DoublePredicate;
 import com.annimon.stream.iterator.PrimitiveExtIterator;
 import com.annimon.stream.iterator.PrimitiveIterator;
+import org.jetbrains.annotations.NotNull;
 
 public class DoubleTakeUntil extends PrimitiveExtIterator.OfDouble {
 
     private final PrimitiveIterator.OfDouble iterator;
     private final DoublePredicate stopPredicate;
 
-    public DoubleTakeUntil(PrimitiveIterator.OfDouble iterator, DoublePredicate stopPredicate) {
+    public DoubleTakeUntil(
+            @NotNull PrimitiveIterator.OfDouble iterator,
+            @NotNull DoublePredicate stopPredicate) {
         this.iterator = iterator;
         this.stopPredicate = stopPredicate;
     }

--- a/stream/src/main/java/com/annimon/stream/operator/DoubleTakeWhile.java
+++ b/stream/src/main/java/com/annimon/stream/operator/DoubleTakeWhile.java
@@ -3,13 +3,16 @@ package com.annimon.stream.operator;
 import com.annimon.stream.function.DoublePredicate;
 import com.annimon.stream.iterator.PrimitiveExtIterator;
 import com.annimon.stream.iterator.PrimitiveIterator;
+import org.jetbrains.annotations.NotNull;
 
 public class DoubleTakeWhile extends PrimitiveExtIterator.OfDouble {
 
     private final PrimitiveIterator.OfDouble iterator;
     private final DoublePredicate predicate;
 
-    public DoubleTakeWhile(PrimitiveIterator.OfDouble iterator, DoublePredicate predicate) {
+    public DoubleTakeWhile(
+            @NotNull PrimitiveIterator.OfDouble iterator,
+            @NotNull DoublePredicate predicate) {
         this.iterator = iterator;
         this.predicate = predicate;
     }

--- a/stream/src/main/java/com/annimon/stream/operator/IntArray.java
+++ b/stream/src/main/java/com/annimon/stream/operator/IntArray.java
@@ -1,13 +1,14 @@
 package com.annimon.stream.operator;
 
 import com.annimon.stream.iterator.PrimitiveIterator;
+import org.jetbrains.annotations.NotNull;
 
 public class IntArray extends PrimitiveIterator.OfInt {
 
     private final int[] values;
     private int index;
 
-    public IntArray(int[] values) {
+    public IntArray(@NotNull int[] values) {
         this.values = values;
         index = 0;
     }

--- a/stream/src/main/java/com/annimon/stream/operator/IntCodePoints.java
+++ b/stream/src/main/java/com/annimon/stream/operator/IntCodePoints.java
@@ -2,6 +2,7 @@ package com.annimon.stream.operator;
 
 import com.annimon.stream.iterator.PrimitiveIterator;
 import java.util.NoSuchElementException;
+import org.jetbrains.annotations.NotNull;
 
 public class IntCodePoints extends PrimitiveIterator.OfInt {
 
@@ -10,7 +11,7 @@ public class IntCodePoints extends PrimitiveIterator.OfInt {
     private int current;
     private int length;
 
-    public IntCodePoints(CharSequence charSequence) {
+    public IntCodePoints(@NotNull CharSequence charSequence) {
         this.charSequence = charSequence;
         isString = (charSequence instanceof String);
         current = 0;

--- a/stream/src/main/java/com/annimon/stream/operator/IntConcat.java
+++ b/stream/src/main/java/com/annimon/stream/operator/IntConcat.java
@@ -1,6 +1,7 @@
 package com.annimon.stream.operator;
 
 import com.annimon.stream.iterator.PrimitiveIterator;
+import org.jetbrains.annotations.NotNull;
 
 public class IntConcat extends PrimitiveIterator.OfInt {
 
@@ -8,7 +9,9 @@ public class IntConcat extends PrimitiveIterator.OfInt {
     private final PrimitiveIterator.OfInt iterator2;
     private boolean firstStreamIsCurrent;
 
-    public IntConcat(PrimitiveIterator.OfInt iterator1, PrimitiveIterator.OfInt iterator2) {
+    public IntConcat(
+            @NotNull PrimitiveIterator.OfInt iterator1,
+            @NotNull PrimitiveIterator.OfInt iterator2) {
         this.iterator1 = iterator1;
         this.iterator2 = iterator2;
         firstStreamIsCurrent = true;

--- a/stream/src/main/java/com/annimon/stream/operator/IntDropWhile.java
+++ b/stream/src/main/java/com/annimon/stream/operator/IntDropWhile.java
@@ -3,13 +3,16 @@ package com.annimon.stream.operator;
 import com.annimon.stream.function.IntPredicate;
 import com.annimon.stream.iterator.PrimitiveExtIterator;
 import com.annimon.stream.iterator.PrimitiveIterator;
+import org.jetbrains.annotations.NotNull;
 
 public class IntDropWhile extends PrimitiveExtIterator.OfInt {
 
     private final PrimitiveIterator.OfInt iterator;
     private final IntPredicate predicate;
 
-    public IntDropWhile(PrimitiveIterator.OfInt iterator, IntPredicate predicate) {
+    public IntDropWhile(
+            @NotNull PrimitiveIterator.OfInt iterator,
+            @NotNull IntPredicate predicate) {
         this.iterator = iterator;
         this.predicate = predicate;
     }

--- a/stream/src/main/java/com/annimon/stream/operator/IntFilter.java
+++ b/stream/src/main/java/com/annimon/stream/operator/IntFilter.java
@@ -3,6 +3,7 @@ package com.annimon.stream.operator;
 import com.annimon.stream.function.IntPredicate;
 import com.annimon.stream.iterator.PrimitiveIterator;
 import java.util.NoSuchElementException;
+import org.jetbrains.annotations.NotNull;
 
 public class IntFilter extends PrimitiveIterator.OfInt {
 
@@ -11,7 +12,9 @@ public class IntFilter extends PrimitiveIterator.OfInt {
     private boolean hasNext, hasNextEvaluated;
     private int next;
 
-    public IntFilter(PrimitiveIterator.OfInt iterator, IntPredicate predicate) {
+    public IntFilter(
+            @NotNull PrimitiveIterator.OfInt iterator,
+            @NotNull IntPredicate predicate) {
         this.iterator = iterator;
         this.predicate = predicate;
     }

--- a/stream/src/main/java/com/annimon/stream/operator/IntFilterIndexed.java
+++ b/stream/src/main/java/com/annimon/stream/operator/IntFilterIndexed.java
@@ -4,6 +4,7 @@ import com.annimon.stream.function.IndexedIntPredicate;
 import com.annimon.stream.iterator.PrimitiveIndexedIterator;
 import com.annimon.stream.iterator.PrimitiveIterator;
 import java.util.NoSuchElementException;
+import org.jetbrains.annotations.NotNull;
 
 public class IntFilterIndexed extends PrimitiveIterator.OfInt {
 
@@ -12,7 +13,9 @@ public class IntFilterIndexed extends PrimitiveIterator.OfInt {
     private boolean hasNext, hasNextEvaluated;
     private int next;
 
-    public IntFilterIndexed(PrimitiveIndexedIterator.OfInt iterator, IndexedIntPredicate predicate) {
+    public IntFilterIndexed(
+            @NotNull PrimitiveIndexedIterator.OfInt iterator,
+            @NotNull IndexedIntPredicate predicate) {
         this.iterator = iterator;
         this.predicate = predicate;
     }

--- a/stream/src/main/java/com/annimon/stream/operator/IntFlatMap.java
+++ b/stream/src/main/java/com/annimon/stream/operator/IntFlatMap.java
@@ -4,6 +4,7 @@ import com.annimon.stream.IntStream;
 import com.annimon.stream.function.IntFunction;
 import com.annimon.stream.iterator.PrimitiveIterator;
 import java.util.NoSuchElementException;
+import org.jetbrains.annotations.NotNull;
 
 public class IntFlatMap extends PrimitiveIterator.OfInt {
 
@@ -12,7 +13,9 @@ public class IntFlatMap extends PrimitiveIterator.OfInt {
     private PrimitiveIterator.OfInt inner;
     private IntStream innerStream;
 
-    public IntFlatMap(PrimitiveIterator.OfInt iterator, IntFunction<? extends IntStream> mapper) {
+    public IntFlatMap(
+            @NotNull PrimitiveIterator.OfInt iterator,
+            @NotNull IntFunction<? extends IntStream> mapper) {
         this.iterator = iterator;
         this.mapper = mapper;
     }

--- a/stream/src/main/java/com/annimon/stream/operator/IntGenerate.java
+++ b/stream/src/main/java/com/annimon/stream/operator/IntGenerate.java
@@ -2,12 +2,13 @@ package com.annimon.stream.operator;
 
 import com.annimon.stream.function.IntSupplier;
 import com.annimon.stream.iterator.PrimitiveIterator;
+import org.jetbrains.annotations.NotNull;
 
 public class IntGenerate extends PrimitiveIterator.OfInt {
 
     private final IntSupplier supplier;
 
-    public IntGenerate(IntSupplier supplier) {
+    public IntGenerate(@NotNull IntSupplier supplier) {
         this.supplier = supplier;
     }
 

--- a/stream/src/main/java/com/annimon/stream/operator/IntIterate.java
+++ b/stream/src/main/java/com/annimon/stream/operator/IntIterate.java
@@ -2,13 +2,14 @@ package com.annimon.stream.operator;
 
 import com.annimon.stream.function.IntUnaryOperator;
 import com.annimon.stream.iterator.PrimitiveIterator;
+import org.jetbrains.annotations.NotNull;
 
 public class IntIterate extends PrimitiveIterator.OfInt {
 
     private final IntUnaryOperator op;
     private int current;
 
-    public IntIterate(int seed, IntUnaryOperator f) {
+    public IntIterate(int seed, @NotNull IntUnaryOperator f) {
         this.op = f;
         current = seed;
     }

--- a/stream/src/main/java/com/annimon/stream/operator/IntLimit.java
+++ b/stream/src/main/java/com/annimon/stream/operator/IntLimit.java
@@ -1,6 +1,7 @@
 package com.annimon.stream.operator;
 
 import com.annimon.stream.iterator.PrimitiveIterator;
+import org.jetbrains.annotations.NotNull;
 
 public class IntLimit extends PrimitiveIterator.OfInt {
 
@@ -8,7 +9,7 @@ public class IntLimit extends PrimitiveIterator.OfInt {
     private final long maxSize;
     private long index;
 
-    public IntLimit(PrimitiveIterator.OfInt iterator, long maxSize) {
+    public IntLimit(@NotNull PrimitiveIterator.OfInt iterator, long maxSize) {
         this.iterator = iterator;
         this.maxSize = maxSize;
         index = 0;

--- a/stream/src/main/java/com/annimon/stream/operator/IntMap.java
+++ b/stream/src/main/java/com/annimon/stream/operator/IntMap.java
@@ -2,13 +2,16 @@ package com.annimon.stream.operator;
 
 import com.annimon.stream.function.IntUnaryOperator;
 import com.annimon.stream.iterator.PrimitiveIterator;
+import org.jetbrains.annotations.NotNull;
 
 public class IntMap extends PrimitiveIterator.OfInt {
 
     private final PrimitiveIterator.OfInt iterator;
     private final IntUnaryOperator mapper;
 
-    public IntMap(PrimitiveIterator.OfInt iterator, IntUnaryOperator mapper) {
+    public IntMap(
+            @NotNull PrimitiveIterator.OfInt iterator,
+            @NotNull IntUnaryOperator mapper) {
         this.iterator = iterator;
         this.mapper = mapper;
     }

--- a/stream/src/main/java/com/annimon/stream/operator/IntMapIndexed.java
+++ b/stream/src/main/java/com/annimon/stream/operator/IntMapIndexed.java
@@ -3,13 +3,16 @@ package com.annimon.stream.operator;
 import com.annimon.stream.function.IntBinaryOperator;
 import com.annimon.stream.iterator.PrimitiveIndexedIterator;
 import com.annimon.stream.iterator.PrimitiveIterator;
+import org.jetbrains.annotations.NotNull;
 
 public class IntMapIndexed extends PrimitiveIterator.OfInt {
 
     private final PrimitiveIndexedIterator.OfInt iterator;
     private final IntBinaryOperator mapper;
 
-    public IntMapIndexed(PrimitiveIndexedIterator.OfInt iterator, IntBinaryOperator mapper) {
+    public IntMapIndexed(
+            @NotNull PrimitiveIndexedIterator.OfInt iterator,
+            @NotNull IntBinaryOperator mapper) {
         this.iterator = iterator;
         this.mapper = mapper;
     }

--- a/stream/src/main/java/com/annimon/stream/operator/IntMapToDouble.java
+++ b/stream/src/main/java/com/annimon/stream/operator/IntMapToDouble.java
@@ -2,13 +2,16 @@ package com.annimon.stream.operator;
 
 import com.annimon.stream.function.IntToDoubleFunction;
 import com.annimon.stream.iterator.PrimitiveIterator;
+import org.jetbrains.annotations.NotNull;
 
 public class IntMapToDouble extends PrimitiveIterator.OfDouble {
 
     private final PrimitiveIterator.OfInt iterator;
     private final IntToDoubleFunction mapper;
 
-    public IntMapToDouble(PrimitiveIterator.OfInt iterator, IntToDoubleFunction mapper) {
+    public IntMapToDouble(
+            @NotNull PrimitiveIterator.OfInt iterator,
+            @NotNull IntToDoubleFunction mapper) {
         this.iterator = iterator;
         this.mapper = mapper;
     }

--- a/stream/src/main/java/com/annimon/stream/operator/IntMapToLong.java
+++ b/stream/src/main/java/com/annimon/stream/operator/IntMapToLong.java
@@ -2,13 +2,16 @@ package com.annimon.stream.operator;
 
 import com.annimon.stream.function.IntToLongFunction;
 import com.annimon.stream.iterator.PrimitiveIterator;
+import org.jetbrains.annotations.NotNull;
 
 public class IntMapToLong extends PrimitiveIterator.OfLong {
 
     private final PrimitiveIterator.OfInt iterator;
     private final IntToLongFunction mapper;
 
-    public IntMapToLong(PrimitiveIterator.OfInt iterator, IntToLongFunction mapper) {
+    public IntMapToLong(
+            @NotNull PrimitiveIterator.OfInt iterator,
+            @NotNull IntToLongFunction mapper) {
         this.iterator = iterator;
         this.mapper = mapper;
     }

--- a/stream/src/main/java/com/annimon/stream/operator/IntMapToObj.java
+++ b/stream/src/main/java/com/annimon/stream/operator/IntMapToObj.java
@@ -3,13 +3,16 @@ package com.annimon.stream.operator;
 import com.annimon.stream.function.IntFunction;
 import com.annimon.stream.iterator.LsaIterator;
 import com.annimon.stream.iterator.PrimitiveIterator;
+import org.jetbrains.annotations.NotNull;
 
 public class IntMapToObj<R> extends LsaIterator<R> {
 
     private final PrimitiveIterator.OfInt iterator;
     private final IntFunction<? extends R> mapper;
 
-    public IntMapToObj(PrimitiveIterator.OfInt iterator, IntFunction<? extends R> mapper) {
+    public IntMapToObj(
+            @NotNull PrimitiveIterator.OfInt iterator,
+            @NotNull IntFunction<? extends R> mapper) {
         this.iterator = iterator;
         this.mapper = mapper;
     }

--- a/stream/src/main/java/com/annimon/stream/operator/IntPeek.java
+++ b/stream/src/main/java/com/annimon/stream/operator/IntPeek.java
@@ -2,13 +2,16 @@ package com.annimon.stream.operator;
 
 import com.annimon.stream.function.IntConsumer;
 import com.annimon.stream.iterator.PrimitiveIterator;
+import org.jetbrains.annotations.NotNull;
 
 public class IntPeek extends PrimitiveIterator.OfInt {
 
     private final PrimitiveIterator.OfInt iterator;
     private final IntConsumer action;
 
-    public IntPeek(PrimitiveIterator.OfInt iterator, IntConsumer action) {
+    public IntPeek(
+            @NotNull PrimitiveIterator.OfInt iterator,
+            @NotNull IntConsumer action) {
         this.iterator = iterator;
         this.action = action;
     }

--- a/stream/src/main/java/com/annimon/stream/operator/IntSample.java
+++ b/stream/src/main/java/com/annimon/stream/operator/IntSample.java
@@ -1,13 +1,14 @@
 package com.annimon.stream.operator;
 
 import com.annimon.stream.iterator.PrimitiveIterator;
+import org.jetbrains.annotations.NotNull;
 
 public class IntSample extends PrimitiveIterator.OfInt {
 
     private final PrimitiveIterator.OfInt iterator;
     private final int stepWidth;
 
-    public IntSample(PrimitiveIterator.OfInt iterator, int stepWidth) {
+    public IntSample(@NotNull PrimitiveIterator.OfInt iterator, int stepWidth) {
         this.iterator = iterator;
         this.stepWidth = stepWidth;
     }

--- a/stream/src/main/java/com/annimon/stream/operator/IntScan.java
+++ b/stream/src/main/java/com/annimon/stream/operator/IntScan.java
@@ -3,13 +3,16 @@ package com.annimon.stream.operator;
 import com.annimon.stream.function.IntBinaryOperator;
 import com.annimon.stream.iterator.PrimitiveExtIterator;
 import com.annimon.stream.iterator.PrimitiveIterator;
+import org.jetbrains.annotations.NotNull;
 
 public class IntScan extends PrimitiveExtIterator.OfInt {
 
     private final PrimitiveIterator.OfInt iterator;
     private final IntBinaryOperator accumulator;
 
-    public IntScan(PrimitiveIterator.OfInt iterator, IntBinaryOperator accumulator) {
+    public IntScan(
+            @NotNull PrimitiveIterator.OfInt iterator,
+            @NotNull IntBinaryOperator accumulator) {
         this.iterator = iterator;
         this.accumulator = accumulator;
     }

--- a/stream/src/main/java/com/annimon/stream/operator/IntScanIdentity.java
+++ b/stream/src/main/java/com/annimon/stream/operator/IntScanIdentity.java
@@ -3,6 +3,7 @@ package com.annimon.stream.operator;
 import com.annimon.stream.function.IntBinaryOperator;
 import com.annimon.stream.iterator.PrimitiveExtIterator;
 import com.annimon.stream.iterator.PrimitiveIterator;
+import org.jetbrains.annotations.NotNull;
 
 public class IntScanIdentity extends PrimitiveExtIterator.OfInt {
 
@@ -10,7 +11,10 @@ public class IntScanIdentity extends PrimitiveExtIterator.OfInt {
     private final int identity;
     private final IntBinaryOperator accumulator;
 
-    public IntScanIdentity(PrimitiveIterator.OfInt iterator, int identity, IntBinaryOperator accumulator) {
+    public IntScanIdentity(
+            @NotNull PrimitiveIterator.OfInt iterator,
+            int identity,
+            @NotNull IntBinaryOperator accumulator) {
         this.iterator = iterator;
         this.identity = identity;
         this.accumulator = accumulator;

--- a/stream/src/main/java/com/annimon/stream/operator/IntSkip.java
+++ b/stream/src/main/java/com/annimon/stream/operator/IntSkip.java
@@ -1,6 +1,7 @@
 package com.annimon.stream.operator;
 
 import com.annimon.stream.iterator.PrimitiveIterator;
+import org.jetbrains.annotations.NotNull;
 
 public class IntSkip extends PrimitiveIterator.OfInt {
 
@@ -8,7 +9,7 @@ public class IntSkip extends PrimitiveIterator.OfInt {
     private final long n;
     private long skipped;
 
-    public IntSkip(PrimitiveIterator.OfInt iterator, long n) {
+    public IntSkip(@NotNull PrimitiveIterator.OfInt iterator, long n) {
         this.iterator = iterator;
         this.n = n;
         skipped = 0;

--- a/stream/src/main/java/com/annimon/stream/operator/IntSorted.java
+++ b/stream/src/main/java/com/annimon/stream/operator/IntSorted.java
@@ -4,6 +4,7 @@ import com.annimon.stream.internal.Operators;
 import com.annimon.stream.iterator.PrimitiveExtIterator;
 import com.annimon.stream.iterator.PrimitiveIterator;
 import java.util.Arrays;
+import org.jetbrains.annotations.NotNull;
 
 public class IntSorted extends PrimitiveExtIterator.OfInt {
 
@@ -11,7 +12,7 @@ public class IntSorted extends PrimitiveExtIterator.OfInt {
     private int index;
     private int[] array;
 
-    public IntSorted(PrimitiveIterator.OfInt iterator) {
+    public IntSorted(@NotNull PrimitiveIterator.OfInt iterator) {
         this.iterator = iterator;
         index = 0;
     }

--- a/stream/src/main/java/com/annimon/stream/operator/IntTakeUntil.java
+++ b/stream/src/main/java/com/annimon/stream/operator/IntTakeUntil.java
@@ -3,13 +3,16 @@ package com.annimon.stream.operator;
 import com.annimon.stream.function.IntPredicate;
 import com.annimon.stream.iterator.PrimitiveExtIterator;
 import com.annimon.stream.iterator.PrimitiveIterator;
+import org.jetbrains.annotations.NotNull;
 
 public class IntTakeUntil extends PrimitiveExtIterator.OfInt {
 
     private final PrimitiveIterator.OfInt iterator;
     private final IntPredicate stopPredicate;
 
-    public IntTakeUntil(PrimitiveIterator.OfInt iterator, IntPredicate stopPredicate) {
+    public IntTakeUntil(
+            @NotNull PrimitiveIterator.OfInt iterator,
+            @NotNull IntPredicate stopPredicate) {
         this.iterator = iterator;
         this.stopPredicate = stopPredicate;
     }

--- a/stream/src/main/java/com/annimon/stream/operator/IntTakeWhile.java
+++ b/stream/src/main/java/com/annimon/stream/operator/IntTakeWhile.java
@@ -3,13 +3,16 @@ package com.annimon.stream.operator;
 import com.annimon.stream.function.IntPredicate;
 import com.annimon.stream.iterator.PrimitiveExtIterator;
 import com.annimon.stream.iterator.PrimitiveIterator;
+import org.jetbrains.annotations.NotNull;
 
 public class IntTakeWhile extends PrimitiveExtIterator.OfInt {
 
     private final PrimitiveIterator.OfInt iterator;
     private final IntPredicate predicate;
 
-    public IntTakeWhile(PrimitiveIterator.OfInt iterator, IntPredicate predicate) {
+    public IntTakeWhile(
+            @NotNull PrimitiveIterator.OfInt iterator,
+            @NotNull IntPredicate predicate) {
         this.iterator = iterator;
         this.predicate = predicate;
     }

--- a/stream/src/main/java/com/annimon/stream/operator/LongArray.java
+++ b/stream/src/main/java/com/annimon/stream/operator/LongArray.java
@@ -1,13 +1,14 @@
 package com.annimon.stream.operator;
 
 import com.annimon.stream.iterator.PrimitiveIterator;
+import org.jetbrains.annotations.NotNull;
 
 public class LongArray extends PrimitiveIterator.OfLong {
 
     private final long[] values;
     private int index;
 
-    public LongArray(long[] values) {
+    public LongArray(@NotNull long[] values) {
         this.values = values;
         index = 0;
     }

--- a/stream/src/main/java/com/annimon/stream/operator/LongConcat.java
+++ b/stream/src/main/java/com/annimon/stream/operator/LongConcat.java
@@ -1,6 +1,7 @@
 package com.annimon.stream.operator;
 
 import com.annimon.stream.iterator.PrimitiveIterator;
+import org.jetbrains.annotations.NotNull;
 
 public class LongConcat extends PrimitiveIterator.OfLong {
 
@@ -8,7 +9,9 @@ public class LongConcat extends PrimitiveIterator.OfLong {
     private final PrimitiveIterator.OfLong iterator2;
     private boolean firstStreamIsCurrent;
 
-    public LongConcat(PrimitiveIterator.OfLong iterator1, PrimitiveIterator.OfLong iterator2) {
+    public LongConcat(
+            @NotNull PrimitiveIterator.OfLong iterator1,
+            @NotNull PrimitiveIterator.OfLong iterator2) {
         this.iterator1 = iterator1;
         this.iterator2 = iterator2;
         firstStreamIsCurrent = true;

--- a/stream/src/main/java/com/annimon/stream/operator/LongDropWhile.java
+++ b/stream/src/main/java/com/annimon/stream/operator/LongDropWhile.java
@@ -3,13 +3,16 @@ package com.annimon.stream.operator;
 import com.annimon.stream.function.LongPredicate;
 import com.annimon.stream.iterator.PrimitiveExtIterator;
 import com.annimon.stream.iterator.PrimitiveIterator;
+import org.jetbrains.annotations.NotNull;
 
 public class LongDropWhile extends PrimitiveExtIterator.OfLong {
 
     private final PrimitiveIterator.OfLong iterator;
     private final LongPredicate predicate;
 
-    public LongDropWhile(PrimitiveIterator.OfLong iterator, LongPredicate predicate) {
+    public LongDropWhile(
+            @NotNull PrimitiveIterator.OfLong iterator,
+            @NotNull LongPredicate predicate) {
         this.iterator = iterator;
         this.predicate = predicate;
     }

--- a/stream/src/main/java/com/annimon/stream/operator/LongFilter.java
+++ b/stream/src/main/java/com/annimon/stream/operator/LongFilter.java
@@ -3,6 +3,7 @@ package com.annimon.stream.operator;
 import com.annimon.stream.function.LongPredicate;
 import com.annimon.stream.iterator.PrimitiveIterator;
 import java.util.NoSuchElementException;
+import org.jetbrains.annotations.NotNull;
 
 public class LongFilter extends PrimitiveIterator.OfLong {
 
@@ -11,7 +12,9 @@ public class LongFilter extends PrimitiveIterator.OfLong {
     private boolean hasNext, hasNextEvaluated;
     private long next;
 
-    public LongFilter(PrimitiveIterator.OfLong iterator, LongPredicate predicate) {
+    public LongFilter(
+            @NotNull PrimitiveIterator.OfLong iterator,
+            @NotNull LongPredicate predicate) {
         this.iterator = iterator;
         this.predicate = predicate;
     }

--- a/stream/src/main/java/com/annimon/stream/operator/LongFilterIndexed.java
+++ b/stream/src/main/java/com/annimon/stream/operator/LongFilterIndexed.java
@@ -4,6 +4,7 @@ import com.annimon.stream.function.IndexedLongPredicate;
 import com.annimon.stream.iterator.PrimitiveIndexedIterator;
 import com.annimon.stream.iterator.PrimitiveIterator;
 import java.util.NoSuchElementException;
+import org.jetbrains.annotations.NotNull;
 
 public class LongFilterIndexed extends PrimitiveIterator.OfLong {
 
@@ -12,7 +13,9 @@ public class LongFilterIndexed extends PrimitiveIterator.OfLong {
     private boolean hasNext, hasNextEvaluated;
     private long next;
 
-    public LongFilterIndexed(PrimitiveIndexedIterator.OfLong iterator, IndexedLongPredicate predicate) {
+    public LongFilterIndexed(
+            @NotNull PrimitiveIndexedIterator.OfLong iterator,
+            @NotNull IndexedLongPredicate predicate) {
         this.iterator = iterator;
         this.predicate = predicate;
     }

--- a/stream/src/main/java/com/annimon/stream/operator/LongFlatMap.java
+++ b/stream/src/main/java/com/annimon/stream/operator/LongFlatMap.java
@@ -4,6 +4,7 @@ import com.annimon.stream.LongStream;
 import com.annimon.stream.function.LongFunction;
 import com.annimon.stream.iterator.PrimitiveIterator;
 import java.util.NoSuchElementException;
+import org.jetbrains.annotations.NotNull;
 
 public class LongFlatMap extends PrimitiveIterator.OfLong {
 
@@ -12,7 +13,9 @@ public class LongFlatMap extends PrimitiveIterator.OfLong {
     private PrimitiveIterator.OfLong inner;
     private LongStream innerStream;
 
-    public LongFlatMap(PrimitiveIterator.OfLong iterator, LongFunction<? extends LongStream> mapper) {
+    public LongFlatMap(
+            @NotNull PrimitiveIterator.OfLong iterator,
+            @NotNull LongFunction<? extends LongStream> mapper) {
         this.iterator = iterator;
         this.mapper = mapper;
     }

--- a/stream/src/main/java/com/annimon/stream/operator/LongGenerate.java
+++ b/stream/src/main/java/com/annimon/stream/operator/LongGenerate.java
@@ -2,12 +2,13 @@ package com.annimon.stream.operator;
 
 import com.annimon.stream.function.LongSupplier;
 import com.annimon.stream.iterator.PrimitiveIterator;
+import org.jetbrains.annotations.NotNull;
 
 public class LongGenerate extends PrimitiveIterator.OfLong {
 
     private final LongSupplier supplier;
 
-    public LongGenerate(LongSupplier supplier) {
+    public LongGenerate(@NotNull LongSupplier supplier) {
         this.supplier = supplier;
     }
 

--- a/stream/src/main/java/com/annimon/stream/operator/LongIterate.java
+++ b/stream/src/main/java/com/annimon/stream/operator/LongIterate.java
@@ -2,13 +2,14 @@ package com.annimon.stream.operator;
 
 import com.annimon.stream.function.LongUnaryOperator;
 import com.annimon.stream.iterator.PrimitiveIterator;
+import org.jetbrains.annotations.NotNull;
 
 public class LongIterate extends PrimitiveIterator.OfLong {
 
     private final LongUnaryOperator op;
     private long current;
 
-    public LongIterate(long seed, LongUnaryOperator f) {
+    public LongIterate(long seed, @NotNull LongUnaryOperator f) {
         this.op = f;
         current = seed;
     }

--- a/stream/src/main/java/com/annimon/stream/operator/LongLimit.java
+++ b/stream/src/main/java/com/annimon/stream/operator/LongLimit.java
@@ -1,6 +1,7 @@
 package com.annimon.stream.operator;
 
 import com.annimon.stream.iterator.PrimitiveIterator;
+import org.jetbrains.annotations.NotNull;
 
 public class LongLimit extends PrimitiveIterator.OfLong {
 
@@ -8,7 +9,7 @@ public class LongLimit extends PrimitiveIterator.OfLong {
     private final long maxSize;
     private long index;
 
-    public LongLimit(PrimitiveIterator.OfLong iterator, long maxSize) {
+    public LongLimit(@NotNull PrimitiveIterator.OfLong iterator, long maxSize) {
         this.iterator = iterator;
         this.maxSize = maxSize;
         index = 0;

--- a/stream/src/main/java/com/annimon/stream/operator/LongMap.java
+++ b/stream/src/main/java/com/annimon/stream/operator/LongMap.java
@@ -2,13 +2,16 @@ package com.annimon.stream.operator;
 
 import com.annimon.stream.function.LongUnaryOperator;
 import com.annimon.stream.iterator.PrimitiveIterator;
+import org.jetbrains.annotations.NotNull;
 
 public class LongMap extends PrimitiveIterator.OfLong {
 
     private final PrimitiveIterator.OfLong iterator;
     private final LongUnaryOperator mapper;
 
-    public LongMap(PrimitiveIterator.OfLong iterator, LongUnaryOperator mapper) {
+    public LongMap(
+            @NotNull PrimitiveIterator.OfLong iterator,
+            @NotNull LongUnaryOperator mapper) {
         this.iterator = iterator;
         this.mapper = mapper;
     }

--- a/stream/src/main/java/com/annimon/stream/operator/LongMapIndexed.java
+++ b/stream/src/main/java/com/annimon/stream/operator/LongMapIndexed.java
@@ -3,13 +3,16 @@ package com.annimon.stream.operator;
 import com.annimon.stream.function.IndexedLongUnaryOperator;
 import com.annimon.stream.iterator.PrimitiveIndexedIterator;
 import com.annimon.stream.iterator.PrimitiveIterator;
+import org.jetbrains.annotations.NotNull;
 
 public class LongMapIndexed extends PrimitiveIterator.OfLong {
 
     private final PrimitiveIndexedIterator.OfLong iterator;
     private final IndexedLongUnaryOperator mapper;
 
-    public LongMapIndexed(PrimitiveIndexedIterator.OfLong iterator, IndexedLongUnaryOperator mapper) {
+    public LongMapIndexed(
+            @NotNull PrimitiveIndexedIterator.OfLong iterator,
+            @NotNull IndexedLongUnaryOperator mapper) {
         this.iterator = iterator;
         this.mapper = mapper;
     }

--- a/stream/src/main/java/com/annimon/stream/operator/LongMapToDouble.java
+++ b/stream/src/main/java/com/annimon/stream/operator/LongMapToDouble.java
@@ -2,13 +2,16 @@ package com.annimon.stream.operator;
 
 import com.annimon.stream.function.LongToDoubleFunction;
 import com.annimon.stream.iterator.PrimitiveIterator;
+import org.jetbrains.annotations.NotNull;
 
 public class LongMapToDouble extends PrimitiveIterator.OfDouble {
 
     private final PrimitiveIterator.OfLong iterator;
     private final LongToDoubleFunction mapper;
 
-    public LongMapToDouble(PrimitiveIterator.OfLong iterator, LongToDoubleFunction mapper) {
+    public LongMapToDouble(
+            @NotNull PrimitiveIterator.OfLong iterator,
+            @NotNull LongToDoubleFunction mapper) {
         this.iterator = iterator;
         this.mapper = mapper;
     }

--- a/stream/src/main/java/com/annimon/stream/operator/LongMapToInt.java
+++ b/stream/src/main/java/com/annimon/stream/operator/LongMapToInt.java
@@ -2,13 +2,16 @@ package com.annimon.stream.operator;
 
 import com.annimon.stream.function.LongToIntFunction;
 import com.annimon.stream.iterator.PrimitiveIterator;
+import org.jetbrains.annotations.NotNull;
 
 public class LongMapToInt extends PrimitiveIterator.OfInt {
 
     private final PrimitiveIterator.OfLong iterator;
     private final LongToIntFunction mapper;
 
-    public LongMapToInt(PrimitiveIterator.OfLong iterator, LongToIntFunction mapper) {
+    public LongMapToInt(
+            @NotNull PrimitiveIterator.OfLong iterator,
+            @NotNull LongToIntFunction mapper) {
         this.iterator = iterator;
         this.mapper = mapper;
     }

--- a/stream/src/main/java/com/annimon/stream/operator/LongMapToObj.java
+++ b/stream/src/main/java/com/annimon/stream/operator/LongMapToObj.java
@@ -3,13 +3,16 @@ package com.annimon.stream.operator;
 import com.annimon.stream.function.LongFunction;
 import com.annimon.stream.iterator.LsaIterator;
 import com.annimon.stream.iterator.PrimitiveIterator;
+import org.jetbrains.annotations.NotNull;
 
 public class LongMapToObj<R> extends LsaIterator<R> {
 
     private final PrimitiveIterator.OfLong iterator;
     private final LongFunction<? extends R> mapper;
 
-    public LongMapToObj(PrimitiveIterator.OfLong iterator, LongFunction<? extends R> mapper) {
+    public LongMapToObj(
+            @NotNull PrimitiveIterator.OfLong iterator,
+            @NotNull LongFunction<? extends R> mapper) {
         this.iterator = iterator;
         this.mapper = mapper;
     }

--- a/stream/src/main/java/com/annimon/stream/operator/LongPeek.java
+++ b/stream/src/main/java/com/annimon/stream/operator/LongPeek.java
@@ -2,13 +2,16 @@ package com.annimon.stream.operator;
 
 import com.annimon.stream.function.LongConsumer;
 import com.annimon.stream.iterator.PrimitiveIterator;
+import org.jetbrains.annotations.NotNull;
 
 public class LongPeek extends PrimitiveIterator.OfLong {
 
     private final PrimitiveIterator.OfLong iterator;
     private final LongConsumer action;
 
-    public LongPeek(PrimitiveIterator.OfLong iterator, LongConsumer action) {
+    public LongPeek(
+            @NotNull PrimitiveIterator.OfLong iterator,
+            @NotNull LongConsumer action) {
         this.iterator = iterator;
         this.action = action;
     }

--- a/stream/src/main/java/com/annimon/stream/operator/LongSample.java
+++ b/stream/src/main/java/com/annimon/stream/operator/LongSample.java
@@ -1,13 +1,14 @@
 package com.annimon.stream.operator;
 
 import com.annimon.stream.iterator.PrimitiveIterator;
+import org.jetbrains.annotations.NotNull;
 
 public class LongSample extends PrimitiveIterator.OfLong {
 
     private final PrimitiveIterator.OfLong iterator;
     private final int stepWidth;
 
-    public LongSample(PrimitiveIterator.OfLong iterator, int stepWidth) {
+    public LongSample(@NotNull PrimitiveIterator.OfLong iterator, int stepWidth) {
         this.iterator = iterator;
         this.stepWidth = stepWidth;
     }

--- a/stream/src/main/java/com/annimon/stream/operator/LongScan.java
+++ b/stream/src/main/java/com/annimon/stream/operator/LongScan.java
@@ -3,13 +3,16 @@ package com.annimon.stream.operator;
 import com.annimon.stream.function.LongBinaryOperator;
 import com.annimon.stream.iterator.PrimitiveExtIterator;
 import com.annimon.stream.iterator.PrimitiveIterator;
+import org.jetbrains.annotations.NotNull;
 
 public class LongScan extends PrimitiveExtIterator.OfLong {
 
     private final PrimitiveIterator.OfLong iterator;
     private final LongBinaryOperator accumulator;
 
-    public LongScan(PrimitiveIterator.OfLong iterator, LongBinaryOperator accumulator) {
+    public LongScan(
+            @NotNull PrimitiveIterator.OfLong iterator,
+            @NotNull LongBinaryOperator accumulator) {
         this.iterator = iterator;
         this.accumulator = accumulator;
     }

--- a/stream/src/main/java/com/annimon/stream/operator/LongScanIdentity.java
+++ b/stream/src/main/java/com/annimon/stream/operator/LongScanIdentity.java
@@ -3,6 +3,7 @@ package com.annimon.stream.operator;
 import com.annimon.stream.function.LongBinaryOperator;
 import com.annimon.stream.iterator.PrimitiveExtIterator;
 import com.annimon.stream.iterator.PrimitiveIterator;
+import org.jetbrains.annotations.NotNull;
 
 public class LongScanIdentity extends PrimitiveExtIterator.OfLong {
 
@@ -10,7 +11,10 @@ public class LongScanIdentity extends PrimitiveExtIterator.OfLong {
     private final long identity;
     private final LongBinaryOperator accumulator;
 
-    public LongScanIdentity(PrimitiveIterator.OfLong iterator, long identity, LongBinaryOperator accumulator) {
+    public LongScanIdentity(
+            @NotNull PrimitiveIterator.OfLong iterator,
+            long identity,
+            @NotNull LongBinaryOperator accumulator) {
         this.iterator = iterator;
         this.identity = identity;
         this.accumulator = accumulator;

--- a/stream/src/main/java/com/annimon/stream/operator/LongSkip.java
+++ b/stream/src/main/java/com/annimon/stream/operator/LongSkip.java
@@ -1,6 +1,7 @@
 package com.annimon.stream.operator;
 
 import com.annimon.stream.iterator.PrimitiveIterator;
+import org.jetbrains.annotations.NotNull;
 
 public class LongSkip extends PrimitiveIterator.OfLong {
 
@@ -8,7 +9,7 @@ public class LongSkip extends PrimitiveIterator.OfLong {
     private final long n;
     private long skipped;
 
-    public LongSkip(PrimitiveIterator.OfLong iterator, long n) {
+    public LongSkip(@NotNull PrimitiveIterator.OfLong iterator, long n) {
         this.iterator = iterator;
         this.n = n;
         skipped = 0;

--- a/stream/src/main/java/com/annimon/stream/operator/LongSorted.java
+++ b/stream/src/main/java/com/annimon/stream/operator/LongSorted.java
@@ -4,6 +4,7 @@ import com.annimon.stream.internal.Operators;
 import com.annimon.stream.iterator.PrimitiveExtIterator;
 import com.annimon.stream.iterator.PrimitiveIterator;
 import java.util.Arrays;
+import org.jetbrains.annotations.NotNull;
 
 public class LongSorted extends PrimitiveExtIterator.OfLong {
 
@@ -11,7 +12,7 @@ public class LongSorted extends PrimitiveExtIterator.OfLong {
     private int index;
     private long[] array;
 
-    public LongSorted(PrimitiveIterator.OfLong iterator) {
+    public LongSorted(@NotNull PrimitiveIterator.OfLong iterator) {
         this.iterator = iterator;
         index = 0;
     }

--- a/stream/src/main/java/com/annimon/stream/operator/LongTakeUntil.java
+++ b/stream/src/main/java/com/annimon/stream/operator/LongTakeUntil.java
@@ -3,13 +3,16 @@ package com.annimon.stream.operator;
 import com.annimon.stream.function.LongPredicate;
 import com.annimon.stream.iterator.PrimitiveExtIterator;
 import com.annimon.stream.iterator.PrimitiveIterator;
+import org.jetbrains.annotations.NotNull;
 
 public class LongTakeUntil extends PrimitiveExtIterator.OfLong {
 
     private final PrimitiveIterator.OfLong iterator;
     private final LongPredicate stopPredicate;
 
-    public LongTakeUntil(PrimitiveIterator.OfLong iterator, LongPredicate stopPredicate) {
+    public LongTakeUntil(
+            @NotNull PrimitiveIterator.OfLong iterator,
+            @NotNull LongPredicate stopPredicate) {
         this.iterator = iterator;
         this.stopPredicate = stopPredicate;
     }

--- a/stream/src/main/java/com/annimon/stream/operator/LongTakeWhile.java
+++ b/stream/src/main/java/com/annimon/stream/operator/LongTakeWhile.java
@@ -3,13 +3,16 @@ package com.annimon.stream.operator;
 import com.annimon.stream.function.LongPredicate;
 import com.annimon.stream.iterator.PrimitiveExtIterator;
 import com.annimon.stream.iterator.PrimitiveIterator;
+import org.jetbrains.annotations.NotNull;
 
 public class LongTakeWhile extends PrimitiveExtIterator.OfLong {
 
     private final PrimitiveIterator.OfLong iterator;
     private final LongPredicate predicate;
 
-    public LongTakeWhile(PrimitiveIterator.OfLong iterator, LongPredicate predicate) {
+    public LongTakeWhile(
+            @NotNull PrimitiveIterator.OfLong iterator,
+            @NotNull LongPredicate predicate) {
         this.iterator = iterator;
         this.predicate = predicate;
     }

--- a/stream/src/main/java/com/annimon/stream/operator/ObjArray.java
+++ b/stream/src/main/java/com/annimon/stream/operator/ObjArray.java
@@ -1,13 +1,14 @@
 package com.annimon.stream.operator;
 
 import com.annimon.stream.iterator.LsaIterator;
+import org.jetbrains.annotations.NotNull;
 
 public class ObjArray<T> extends LsaIterator<T> {
 
     private final T[] elements;
     private int index;
 
-    public ObjArray(T[] elements) {
+    public ObjArray(@NotNull T[] elements) {
         this.elements = elements;
         index = 0;
     }

--- a/stream/src/main/java/com/annimon/stream/operator/ObjChunkBy.java
+++ b/stream/src/main/java/com/annimon/stream/operator/ObjChunkBy.java
@@ -5,6 +5,7 @@ import com.annimon.stream.iterator.LsaIterator;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import org.jetbrains.annotations.NotNull;
 
 public class ObjChunkBy<T, K> extends LsaIterator<List<T>> {
 
@@ -13,7 +14,9 @@ public class ObjChunkBy<T, K> extends LsaIterator<List<T>> {
     private T next;
     private boolean peekedNext;
 
-    public ObjChunkBy(Iterator<? extends T> iterator, Function<? super T, ? extends K> classifier) {
+    public ObjChunkBy(
+            @NotNull Iterator<? extends T> iterator,
+            @NotNull Function<? super T, ? extends K> classifier) {
         this.iterator = iterator;
         this.classifier = classifier;
     }

--- a/stream/src/main/java/com/annimon/stream/operator/ObjConcat.java
+++ b/stream/src/main/java/com/annimon/stream/operator/ObjConcat.java
@@ -2,6 +2,7 @@ package com.annimon.stream.operator;
 
 import com.annimon.stream.iterator.LsaExtIterator;
 import java.util.Iterator;
+import org.jetbrains.annotations.NotNull;
 
 public class ObjConcat<T> extends LsaExtIterator<T> {
 
@@ -9,7 +10,9 @@ public class ObjConcat<T> extends LsaExtIterator<T> {
     private final Iterator<? extends T> iterator2;
     private boolean firstStreamIsCurrent;
 
-    public ObjConcat(Iterator<? extends T> iterator1, Iterator<? extends T> iterator2) {
+    public ObjConcat(
+            @NotNull Iterator<? extends T> iterator1,
+            @NotNull Iterator<? extends T> iterator2) {
         this.iterator1 = iterator1;
         this.iterator2 = iterator2;
         firstStreamIsCurrent = true;

--- a/stream/src/main/java/com/annimon/stream/operator/ObjDistinct.java
+++ b/stream/src/main/java/com/annimon/stream/operator/ObjDistinct.java
@@ -4,13 +4,14 @@ import com.annimon.stream.iterator.LsaExtIterator;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
+import org.jetbrains.annotations.NotNull;
 
 public class ObjDistinct<T> extends LsaExtIterator<T> {
 
     private final Iterator<? extends T> iterator;
     private final Set<T> set;
 
-    public ObjDistinct(Iterator<? extends T> iterator) {
+    public ObjDistinct(@NotNull Iterator<? extends T> iterator) {
         this.iterator = iterator;
         set = new HashSet<T>();
     }

--- a/stream/src/main/java/com/annimon/stream/operator/ObjDistinctBy.java
+++ b/stream/src/main/java/com/annimon/stream/operator/ObjDistinctBy.java
@@ -5,6 +5,7 @@ import com.annimon.stream.iterator.LsaExtIterator;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
+import org.jetbrains.annotations.NotNull;
 
 public class ObjDistinctBy<T, K> extends LsaExtIterator<T> {
 
@@ -12,7 +13,9 @@ public class ObjDistinctBy<T, K> extends LsaExtIterator<T> {
     private final Function<? super T, ? extends K> classifier;
     private final Set<K> set;
 
-    public ObjDistinctBy(Iterator<? extends T> iterator, Function<? super T, ? extends K> classifier) {
+    public ObjDistinctBy(
+            @NotNull Iterator<? extends T> iterator,
+            @NotNull Function<? super T, ? extends K> classifier) {
         this.iterator = iterator;
         this.classifier = classifier;
         set = new HashSet<K>();

--- a/stream/src/main/java/com/annimon/stream/operator/ObjDropWhile.java
+++ b/stream/src/main/java/com/annimon/stream/operator/ObjDropWhile.java
@@ -3,13 +3,16 @@ package com.annimon.stream.operator;
 import com.annimon.stream.function.Predicate;
 import com.annimon.stream.iterator.LsaExtIterator;
 import java.util.Iterator;
+import org.jetbrains.annotations.NotNull;
 
 public class ObjDropWhile<T> extends LsaExtIterator<T> {
 
     private final Iterator<? extends T> iterator;
     private final Predicate<? super T> predicate;
 
-    public ObjDropWhile(Iterator<? extends T> iterator, Predicate<? super T> predicate) {
+    public ObjDropWhile(
+            @NotNull Iterator<? extends T> iterator,
+            @NotNull Predicate<? super T> predicate) {
         this.iterator = iterator;
         this.predicate = predicate;
     }

--- a/stream/src/main/java/com/annimon/stream/operator/ObjDropWhileIndexed.java
+++ b/stream/src/main/java/com/annimon/stream/operator/ObjDropWhileIndexed.java
@@ -3,13 +3,16 @@ package com.annimon.stream.operator;
 import com.annimon.stream.function.IndexedPredicate;
 import com.annimon.stream.iterator.IndexedIterator;
 import com.annimon.stream.iterator.LsaExtIterator;
+import org.jetbrains.annotations.NotNull;
 
 public class ObjDropWhileIndexed<T> extends LsaExtIterator<T> {
 
     private final IndexedIterator<? extends T> iterator;
     private final IndexedPredicate<? super T> predicate;
 
-    public ObjDropWhileIndexed(IndexedIterator<? extends T> iterator, IndexedPredicate<? super T> predicate) {
+    public ObjDropWhileIndexed(
+            @NotNull IndexedIterator<? extends T> iterator,
+            @NotNull IndexedPredicate<? super T> predicate) {
         this.iterator = iterator;
         this.predicate = predicate;
     }

--- a/stream/src/main/java/com/annimon/stream/operator/ObjFilter.java
+++ b/stream/src/main/java/com/annimon/stream/operator/ObjFilter.java
@@ -3,6 +3,7 @@ package com.annimon.stream.operator;
 import com.annimon.stream.function.Predicate;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+import org.jetbrains.annotations.NotNull;
 
 public class ObjFilter<T> implements Iterator<T> {
 
@@ -11,7 +12,9 @@ public class ObjFilter<T> implements Iterator<T> {
     private boolean hasNext, hasNextEvaluated;
     private T next;
 
-    public ObjFilter(Iterator<? extends T> iterator, Predicate<? super T> predicate) {
+    public ObjFilter(
+            @NotNull Iterator<? extends T> iterator,
+            @NotNull Predicate<? super T> predicate) {
         this.iterator = iterator;
         this.predicate = predicate;
     }

--- a/stream/src/main/java/com/annimon/stream/operator/ObjFilterIndexed.java
+++ b/stream/src/main/java/com/annimon/stream/operator/ObjFilterIndexed.java
@@ -4,6 +4,7 @@ import com.annimon.stream.function.IndexedPredicate;
 import com.annimon.stream.iterator.IndexedIterator;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+import org.jetbrains.annotations.NotNull;
 
 public class ObjFilterIndexed<T> implements Iterator<T> {
 
@@ -12,7 +13,9 @@ public class ObjFilterIndexed<T> implements Iterator<T> {
     private boolean hasNext, hasNextEvaluated;
     private T next;
 
-    public ObjFilterIndexed(IndexedIterator<? extends T> iterator, IndexedPredicate<? super T> predicate) {
+    public ObjFilterIndexed(
+            @NotNull IndexedIterator<? extends T> iterator,
+            @NotNull IndexedPredicate<? super T> predicate) {
         this.iterator = iterator;
         this.predicate = predicate;
     }

--- a/stream/src/main/java/com/annimon/stream/operator/ObjFlatMap.java
+++ b/stream/src/main/java/com/annimon/stream/operator/ObjFlatMap.java
@@ -4,6 +4,7 @@ import com.annimon.stream.Stream;
 import com.annimon.stream.function.Function;
 import com.annimon.stream.iterator.LsaExtIterator;
 import java.util.Iterator;
+import org.jetbrains.annotations.NotNull;
 
 public class ObjFlatMap<T, R> extends LsaExtIterator<R> {
 
@@ -12,8 +13,9 @@ public class ObjFlatMap<T, R> extends LsaExtIterator<R> {
     private Iterator<? extends R> inner;
     private Stream<? extends R> innerStream;
 
-    public ObjFlatMap(Iterator<? extends T> iterator,
-            Function<? super T, ? extends Stream<? extends R>> mapper) {
+    public ObjFlatMap(
+            @NotNull Iterator<? extends T> iterator,
+            @NotNull Function<? super T, ? extends Stream<? extends R>> mapper) {
         this.iterator = iterator;
         this.mapper = mapper;
     }

--- a/stream/src/main/java/com/annimon/stream/operator/ObjFlatMapToDouble.java
+++ b/stream/src/main/java/com/annimon/stream/operator/ObjFlatMapToDouble.java
@@ -5,6 +5,7 @@ import com.annimon.stream.function.Function;
 import com.annimon.stream.iterator.PrimitiveExtIterator;
 import com.annimon.stream.iterator.PrimitiveIterator;
 import java.util.Iterator;
+import org.jetbrains.annotations.NotNull;
 
 public class ObjFlatMapToDouble<T> extends PrimitiveExtIterator.OfDouble {
 
@@ -12,8 +13,9 @@ public class ObjFlatMapToDouble<T> extends PrimitiveExtIterator.OfDouble {
     private final Function<? super T, ? extends DoubleStream> mapper;
     private PrimitiveIterator.OfDouble inner;
 
-    public ObjFlatMapToDouble(Iterator<? extends T> iterator,
-            Function<? super T, ? extends DoubleStream> mapper) {
+    public ObjFlatMapToDouble(
+            @NotNull Iterator<? extends T> iterator,
+            @NotNull Function<? super T, ? extends DoubleStream> mapper) {
         this.iterator = iterator;
         this.mapper = mapper;
     }

--- a/stream/src/main/java/com/annimon/stream/operator/ObjFlatMapToInt.java
+++ b/stream/src/main/java/com/annimon/stream/operator/ObjFlatMapToInt.java
@@ -5,6 +5,7 @@ import com.annimon.stream.function.Function;
 import com.annimon.stream.iterator.PrimitiveExtIterator;
 import com.annimon.stream.iterator.PrimitiveIterator;
 import java.util.Iterator;
+import org.jetbrains.annotations.NotNull;
 
 public class ObjFlatMapToInt<T> extends PrimitiveExtIterator.OfInt {
 
@@ -12,7 +13,9 @@ public class ObjFlatMapToInt<T> extends PrimitiveExtIterator.OfInt {
     private final Function<? super T, ? extends IntStream> mapper;
     private PrimitiveIterator.OfInt inner;
 
-    public ObjFlatMapToInt(Iterator<? extends T> iterator, Function<? super T, ? extends IntStream> mapper) {
+    public ObjFlatMapToInt(
+            @NotNull Iterator<? extends T> iterator,
+            @NotNull Function<? super T, ? extends IntStream> mapper) {
         this.iterator = iterator;
         this.mapper = mapper;
     }

--- a/stream/src/main/java/com/annimon/stream/operator/ObjFlatMapToLong.java
+++ b/stream/src/main/java/com/annimon/stream/operator/ObjFlatMapToLong.java
@@ -5,6 +5,7 @@ import com.annimon.stream.function.Function;
 import com.annimon.stream.iterator.PrimitiveExtIterator;
 import com.annimon.stream.iterator.PrimitiveIterator;
 import java.util.Iterator;
+import org.jetbrains.annotations.NotNull;
 
 public class ObjFlatMapToLong<T> extends PrimitiveExtIterator.OfLong {
 
@@ -12,8 +13,9 @@ public class ObjFlatMapToLong<T> extends PrimitiveExtIterator.OfLong {
     private final Function<? super T, ? extends LongStream> mapper;
     private PrimitiveIterator.OfLong inner;
 
-    public ObjFlatMapToLong(Iterator<? extends T> iterator,
-            Function<? super T, ? extends LongStream> mapper) {
+    public ObjFlatMapToLong(
+            @NotNull Iterator<? extends T> iterator,
+            @NotNull Function<? super T, ? extends LongStream> mapper) {
         this.iterator = iterator;
         this.mapper = mapper;
     }

--- a/stream/src/main/java/com/annimon/stream/operator/ObjGenerate.java
+++ b/stream/src/main/java/com/annimon/stream/operator/ObjGenerate.java
@@ -2,12 +2,13 @@ package com.annimon.stream.operator;
 
 import com.annimon.stream.function.Supplier;
 import com.annimon.stream.iterator.LsaIterator;
+import org.jetbrains.annotations.NotNull;
 
 public class ObjGenerate<T> extends LsaIterator<T> {
 
     private final Supplier<T> supplier;
 
-    public ObjGenerate(Supplier<T> supplier) {
+    public ObjGenerate(@NotNull Supplier<T> supplier) {
         this.supplier = supplier;
     }
 

--- a/stream/src/main/java/com/annimon/stream/operator/ObjIterate.java
+++ b/stream/src/main/java/com/annimon/stream/operator/ObjIterate.java
@@ -2,13 +2,15 @@ package com.annimon.stream.operator;
 
 import com.annimon.stream.function.UnaryOperator;
 import com.annimon.stream.iterator.LsaIterator;
+import jdk.internal.jline.internal.Nullable;
+import org.jetbrains.annotations.NotNull;
 
 public class ObjIterate<T> extends LsaIterator<T> {
 
     private final UnaryOperator<T> op;
     private T current;
 
-    public ObjIterate(T seed, UnaryOperator<T> op) {
+    public ObjIterate(@Nullable T seed, @NotNull UnaryOperator<T> op) {
         this.op = op;
         current = seed;
     }

--- a/stream/src/main/java/com/annimon/stream/operator/ObjIterate.java
+++ b/stream/src/main/java/com/annimon/stream/operator/ObjIterate.java
@@ -2,8 +2,8 @@ package com.annimon.stream.operator;
 
 import com.annimon.stream.function.UnaryOperator;
 import com.annimon.stream.iterator.LsaIterator;
-import jdk.internal.jline.internal.Nullable;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class ObjIterate<T> extends LsaIterator<T> {
 

--- a/stream/src/main/java/com/annimon/stream/operator/ObjLimit.java
+++ b/stream/src/main/java/com/annimon/stream/operator/ObjLimit.java
@@ -2,6 +2,7 @@ package com.annimon.stream.operator;
 
 import com.annimon.stream.iterator.LsaIterator;
 import java.util.Iterator;
+import org.jetbrains.annotations.NotNull;
 
 public class ObjLimit<T> extends LsaIterator<T> {
 
@@ -9,7 +10,8 @@ public class ObjLimit<T> extends LsaIterator<T> {
     private final long maxSize;
     private long index;
 
-    public ObjLimit(Iterator<? extends T> iterator, long maxSize) {
+    public ObjLimit(
+            @NotNull Iterator<? extends T> iterator, long maxSize) {
         this.iterator = iterator;
         this.maxSize = maxSize;
         index = 0;

--- a/stream/src/main/java/com/annimon/stream/operator/ObjMap.java
+++ b/stream/src/main/java/com/annimon/stream/operator/ObjMap.java
@@ -3,13 +3,16 @@ package com.annimon.stream.operator;
 import com.annimon.stream.function.Function;
 import com.annimon.stream.iterator.LsaIterator;
 import java.util.Iterator;
+import org.jetbrains.annotations.NotNull;
 
 public class ObjMap<T, R> extends LsaIterator<R> {
 
     private final Iterator<? extends T> iterator;
     private final Function<? super T, ? extends R> mapper;
 
-    public ObjMap(Iterator<? extends T> iterator, Function<? super T, ? extends R> mapper) {
+    public ObjMap(
+            @NotNull Iterator<? extends T> iterator,
+            @NotNull Function<? super T, ? extends R> mapper) {
         this.iterator = iterator;
         this.mapper = mapper;
     }

--- a/stream/src/main/java/com/annimon/stream/operator/ObjMapIndexed.java
+++ b/stream/src/main/java/com/annimon/stream/operator/ObjMapIndexed.java
@@ -3,13 +3,16 @@ package com.annimon.stream.operator;
 import com.annimon.stream.function.IndexedFunction;
 import com.annimon.stream.iterator.IndexedIterator;
 import com.annimon.stream.iterator.LsaIterator;
+import org.jetbrains.annotations.NotNull;
 
 public class ObjMapIndexed<T, R> extends LsaIterator<R> {
 
     private final IndexedIterator<? extends T> iterator;
     private final IndexedFunction<? super T, ? extends R> mapper;
 
-    public ObjMapIndexed(IndexedIterator<? extends T> iterator, IndexedFunction<? super T, ? extends R> mapper) {
+    public ObjMapIndexed(
+            @NotNull IndexedIterator<? extends T> iterator,
+            @NotNull IndexedFunction<? super T, ? extends R> mapper) {
         this.iterator = iterator;
         this.mapper = mapper;
     }

--- a/stream/src/main/java/com/annimon/stream/operator/ObjMapToDouble.java
+++ b/stream/src/main/java/com/annimon/stream/operator/ObjMapToDouble.java
@@ -3,13 +3,16 @@ package com.annimon.stream.operator;
 import com.annimon.stream.function.ToDoubleFunction;
 import com.annimon.stream.iterator.PrimitiveIterator;
 import java.util.Iterator;
+import org.jetbrains.annotations.NotNull;
 
 public class ObjMapToDouble<T> extends PrimitiveIterator.OfDouble {
 
     private final Iterator<? extends T> iterator;
     private final ToDoubleFunction<? super T> mapper;
 
-    public ObjMapToDouble(Iterator<? extends T> iterator, ToDoubleFunction<? super T> mapper) {
+    public ObjMapToDouble(
+            @NotNull Iterator<? extends T> iterator,
+            @NotNull ToDoubleFunction<? super T> mapper) {
         this.iterator = iterator;
         this.mapper = mapper;
     }

--- a/stream/src/main/java/com/annimon/stream/operator/ObjMapToInt.java
+++ b/stream/src/main/java/com/annimon/stream/operator/ObjMapToInt.java
@@ -3,13 +3,16 @@ package com.annimon.stream.operator;
 import com.annimon.stream.function.ToIntFunction;
 import com.annimon.stream.iterator.PrimitiveIterator;
 import java.util.Iterator;
+import org.jetbrains.annotations.NotNull;
 
 public class ObjMapToInt<T> extends PrimitiveIterator.OfInt {
 
     private final Iterator<? extends T> iterator;
     private final ToIntFunction<? super T> mapper;
 
-    public ObjMapToInt(Iterator<? extends T> iterator, ToIntFunction<? super T> mapper) {
+    public ObjMapToInt(
+            @NotNull Iterator<? extends T> iterator,
+            @NotNull ToIntFunction<? super T> mapper) {
         this.iterator = iterator;
         this.mapper = mapper;
     }

--- a/stream/src/main/java/com/annimon/stream/operator/ObjMapToLong.java
+++ b/stream/src/main/java/com/annimon/stream/operator/ObjMapToLong.java
@@ -3,13 +3,16 @@ package com.annimon.stream.operator;
 import com.annimon.stream.function.ToLongFunction;
 import com.annimon.stream.iterator.PrimitiveIterator;
 import java.util.Iterator;
+import org.jetbrains.annotations.NotNull;
 
 public class ObjMapToLong<T> extends PrimitiveIterator.OfLong {
 
     private final Iterator<? extends T> iterator;
     private final ToLongFunction<? super T> mapper;
 
-    public ObjMapToLong(Iterator<? extends T> iterator, ToLongFunction<? super T> mapper) {
+    public ObjMapToLong(
+            @NotNull Iterator<? extends T> iterator,
+            @NotNull ToLongFunction<? super T> mapper) {
         this.iterator = iterator;
         this.mapper = mapper;
     }

--- a/stream/src/main/java/com/annimon/stream/operator/ObjMerge.java
+++ b/stream/src/main/java/com/annimon/stream/operator/ObjMerge.java
@@ -5,6 +5,7 @@ import com.annimon.stream.iterator.LsaIterator;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.Queue;
+import org.jetbrains.annotations.NotNull;
 
 public class ObjMerge<T> extends LsaIterator<T> {
 
@@ -18,8 +19,10 @@ public class ObjMerge<T> extends LsaIterator<T> {
     private final Queue<T> buffer1;
     private final Queue<T> buffer2;
 
-    public ObjMerge(Iterator<? extends T> iterator1, Iterator<? extends T> iterator2,
-                    BiFunction<? super T, ? super T, MergeResult> selector) {
+    public ObjMerge(
+            @NotNull Iterator<? extends T> iterator1,
+            @NotNull Iterator<? extends T> iterator2,
+            @NotNull BiFunction<? super T, ? super T, MergeResult> selector) {
         this.iterator1 = iterator1;
         this.iterator2 = iterator2;
         this.selector = selector;

--- a/stream/src/main/java/com/annimon/stream/operator/ObjPeek.java
+++ b/stream/src/main/java/com/annimon/stream/operator/ObjPeek.java
@@ -3,13 +3,16 @@ package com.annimon.stream.operator;
 import com.annimon.stream.function.Consumer;
 import com.annimon.stream.iterator.LsaIterator;
 import java.util.Iterator;
+import org.jetbrains.annotations.NotNull;
 
 public class ObjPeek<T> extends LsaIterator<T> {
 
     private final Iterator<? extends T> iterator;
     private final Consumer<? super T> action;
 
-    public ObjPeek(Iterator<? extends T> iterator, Consumer<? super T> action) {
+    public ObjPeek(
+            @NotNull Iterator<? extends T> iterator,
+            @NotNull Consumer<? super T> action) {
         this.iterator = iterator;
         this.action = action;
     }

--- a/stream/src/main/java/com/annimon/stream/operator/ObjScan.java
+++ b/stream/src/main/java/com/annimon/stream/operator/ObjScan.java
@@ -3,13 +3,16 @@ package com.annimon.stream.operator;
 import com.annimon.stream.function.BiFunction;
 import com.annimon.stream.iterator.LsaExtIterator;
 import java.util.Iterator;
+import org.jetbrains.annotations.NotNull;
 
 public class ObjScan<T> extends LsaExtIterator<T> {
 
     private final Iterator<? extends T> iterator;
     private final BiFunction<T, T, T> accumulator;
 
-    public ObjScan(Iterator<? extends T> iterator, BiFunction<T, T, T> accumulator) {
+    public ObjScan(
+            @NotNull Iterator<? extends T> iterator,
+            @NotNull BiFunction<T, T, T> accumulator) {
         this.iterator = iterator;
         this.accumulator = accumulator;
     }

--- a/stream/src/main/java/com/annimon/stream/operator/ObjScanIdentity.java
+++ b/stream/src/main/java/com/annimon/stream/operator/ObjScanIdentity.java
@@ -3,6 +3,8 @@ package com.annimon.stream.operator;
 import com.annimon.stream.function.BiFunction;
 import com.annimon.stream.iterator.LsaExtIterator;
 import java.util.Iterator;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class ObjScanIdentity<T, R> extends LsaExtIterator<R> {
 
@@ -10,8 +12,10 @@ public class ObjScanIdentity<T, R> extends LsaExtIterator<R> {
     private final R identity;
     private final BiFunction<? super R, ? super T, ? extends R> accumulator;
 
-    public ObjScanIdentity(Iterator<? extends T> iterator, R identity,
-            BiFunction<? super R, ? super T, ? extends R> accumulator) {
+    public ObjScanIdentity(
+            @NotNull Iterator<? extends T> iterator,
+            @Nullable R identity,
+            @NotNull BiFunction<? super R, ? super T, ? extends R> accumulator) {
         this.iterator = iterator;
         this.identity = identity;
         this.accumulator = accumulator;

--- a/stream/src/main/java/com/annimon/stream/operator/ObjSkip.java
+++ b/stream/src/main/java/com/annimon/stream/operator/ObjSkip.java
@@ -2,6 +2,7 @@ package com.annimon.stream.operator;
 
 import com.annimon.stream.iterator.LsaIterator;
 import java.util.Iterator;
+import org.jetbrains.annotations.NotNull;
 
 public class ObjSkip<T> extends LsaIterator<T> {
 
@@ -9,7 +10,7 @@ public class ObjSkip<T> extends LsaIterator<T> {
     private final long n;
     private long skipped;
 
-    public ObjSkip(Iterator<? extends T> iterator, long n) {
+    public ObjSkip(@NotNull Iterator<? extends T> iterator, long n) {
         this.iterator = iterator;
         this.n = n;
         skipped = 0;

--- a/stream/src/main/java/com/annimon/stream/operator/ObjSlidingWindow.java
+++ b/stream/src/main/java/com/annimon/stream/operator/ObjSlidingWindow.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Queue;
+import org.jetbrains.annotations.NotNull;
 
 public class ObjSlidingWindow<T> extends LsaIterator<List<T>> {
 
@@ -14,7 +15,9 @@ public class ObjSlidingWindow<T> extends LsaIterator<List<T>> {
     private final int windowSize;
     private final int stepWidth;
 
-    public ObjSlidingWindow(Iterator<? extends T> iterator, int windowSize, int stepWidth) {
+    public ObjSlidingWindow(
+            @NotNull Iterator<? extends T> iterator,
+            int windowSize, int stepWidth) {
         this.iterator = iterator;
         this.windowSize = windowSize;
         this.stepWidth = stepWidth;

--- a/stream/src/main/java/com/annimon/stream/operator/ObjSorted.java
+++ b/stream/src/main/java/com/annimon/stream/operator/ObjSorted.java
@@ -6,6 +6,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
+import org.jetbrains.annotations.NotNull;
 
 public class ObjSorted<T> extends LsaExtIterator<T> {
 
@@ -13,7 +14,9 @@ public class ObjSorted<T> extends LsaExtIterator<T> {
     private final Comparator<? super T> comparator;
     private Iterator<T> sortedIterator;
 
-    public ObjSorted(Iterator<? extends T> iterator, Comparator<? super T> comparator) {
+    public ObjSorted(
+            @NotNull Iterator<? extends T> iterator,
+            @NotNull Comparator<? super T> comparator) {
         this.iterator = iterator;
         this.comparator = comparator;
     }

--- a/stream/src/main/java/com/annimon/stream/operator/ObjSorted.java
+++ b/stream/src/main/java/com/annimon/stream/operator/ObjSorted.java
@@ -7,6 +7,7 @@ import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class ObjSorted<T> extends LsaExtIterator<T> {
 
@@ -16,7 +17,7 @@ public class ObjSorted<T> extends LsaExtIterator<T> {
 
     public ObjSorted(
             @NotNull Iterator<? extends T> iterator,
-            @NotNull Comparator<? super T> comparator) {
+            @Nullable Comparator<? super T> comparator) {
         this.iterator = iterator;
         this.comparator = comparator;
     }

--- a/stream/src/main/java/com/annimon/stream/operator/ObjTakeUntil.java
+++ b/stream/src/main/java/com/annimon/stream/operator/ObjTakeUntil.java
@@ -3,13 +3,16 @@ package com.annimon.stream.operator;
 import com.annimon.stream.function.Predicate;
 import com.annimon.stream.iterator.LsaExtIterator;
 import java.util.Iterator;
+import org.jetbrains.annotations.NotNull;
 
 public class ObjTakeUntil<T> extends LsaExtIterator<T> {
 
     private final Iterator<? extends T> iterator;
     private final Predicate<? super T> stopPredicate;
 
-    public ObjTakeUntil(Iterator<? extends T> iterator, Predicate<? super T> predicate) {
+    public ObjTakeUntil(
+            @NotNull Iterator<? extends T> iterator,
+            @NotNull Predicate<? super T> predicate) {
         this.iterator = iterator;
         this.stopPredicate = predicate;
     }

--- a/stream/src/main/java/com/annimon/stream/operator/ObjTakeUntilIndexed.java
+++ b/stream/src/main/java/com/annimon/stream/operator/ObjTakeUntilIndexed.java
@@ -3,13 +3,16 @@ package com.annimon.stream.operator;
 import com.annimon.stream.function.IndexedPredicate;
 import com.annimon.stream.iterator.IndexedIterator;
 import com.annimon.stream.iterator.LsaExtIterator;
+import org.jetbrains.annotations.NotNull;
 
 public class ObjTakeUntilIndexed<T> extends LsaExtIterator<T> {
 
     private final IndexedIterator<? extends T> iterator;
     private final IndexedPredicate<? super T> stopPredicate;
 
-    public ObjTakeUntilIndexed(IndexedIterator<? extends T> iterator, IndexedPredicate<? super T> predicate) {
+    public ObjTakeUntilIndexed(
+            @NotNull IndexedIterator<? extends T> iterator,
+            @NotNull IndexedPredicate<? super T> predicate) {
         this.iterator = iterator;
         this.stopPredicate = predicate;
     }

--- a/stream/src/main/java/com/annimon/stream/operator/ObjTakeWhile.java
+++ b/stream/src/main/java/com/annimon/stream/operator/ObjTakeWhile.java
@@ -3,13 +3,16 @@ package com.annimon.stream.operator;
 import com.annimon.stream.function.Predicate;
 import com.annimon.stream.iterator.LsaExtIterator;
 import java.util.Iterator;
+import org.jetbrains.annotations.NotNull;
 
 public class ObjTakeWhile<T> extends LsaExtIterator<T> {
 
     private final Iterator<? extends T> iterator;
     private final Predicate<? super T> predicate;
 
-    public ObjTakeWhile(Iterator<? extends T> iterator, Predicate<? super T> predicate) {
+    public ObjTakeWhile(
+            @NotNull Iterator<? extends T> iterator,
+            @NotNull Predicate<? super T> predicate) {
         this.iterator = iterator;
         this.predicate = predicate;
     }

--- a/stream/src/main/java/com/annimon/stream/operator/ObjTakeWhileIndexed.java
+++ b/stream/src/main/java/com/annimon/stream/operator/ObjTakeWhileIndexed.java
@@ -3,13 +3,16 @@ package com.annimon.stream.operator;
 import com.annimon.stream.function.IndexedPredicate;
 import com.annimon.stream.iterator.IndexedIterator;
 import com.annimon.stream.iterator.LsaExtIterator;
+import org.jetbrains.annotations.NotNull;
 
 public class ObjTakeWhileIndexed<T> extends LsaExtIterator<T> {
 
     private final IndexedIterator<? extends T> iterator;
     private final IndexedPredicate<? super T> predicate;
 
-    public ObjTakeWhileIndexed(IndexedIterator<? extends T> iterator, IndexedPredicate<? super T> predicate) {
+    public ObjTakeWhileIndexed(
+            @NotNull IndexedIterator<? extends T> iterator,
+            @NotNull IndexedPredicate<? super T> predicate) {
         this.iterator = iterator;
         this.predicate = predicate;
     }

--- a/stream/src/main/java/com/annimon/stream/operator/ObjZip.java
+++ b/stream/src/main/java/com/annimon/stream/operator/ObjZip.java
@@ -3,6 +3,7 @@ package com.annimon.stream.operator;
 import com.annimon.stream.function.BiFunction;
 import com.annimon.stream.iterator.LsaIterator;
 import java.util.Iterator;
+import org.jetbrains.annotations.NotNull;
 
 public class ObjZip<F, S, R> extends LsaIterator<R> {
 
@@ -10,8 +11,10 @@ public class ObjZip<F, S, R> extends LsaIterator<R> {
     private final Iterator<? extends S> iterator2;
     private final BiFunction<? super F, ? super S, ? extends R> combiner;
 
-    public ObjZip(Iterator<? extends F> iterator1, Iterator<? extends S> iterator2,
-            BiFunction<? super F, ? super S, ? extends R> combiner) {
+    public ObjZip(
+            @NotNull Iterator<? extends F> iterator1,
+            @NotNull Iterator<? extends S> iterator2,
+            @NotNull BiFunction<? super F, ? super S, ? extends R> combiner) {
         this.iterator1 = iterator1;
         this.iterator2 = iterator2;
         this.combiner = combiner;


### PR DESCRIPTION
As suggested in #176 

Note, this project can't be targeted to Java 8 version, so we are limited to using 'org.jetbrains:annotations-java5'. Moreover, since type annotations aren't supported in pre-Java 8 version, we can't mark types as nullable: `Function<@NotNull T, @Nullable R>`, `Optional<@NotNull T>`, etc.